### PR TITLE
motd.c:motd_memory_count(): fixed invalid memory stats due to uncount…

### DIFF
--- a/ircd/motd.c
+++ b/ircd/motd.c
@@ -470,12 +470,14 @@ motd_memory_count(struct Client *cptr)
     mt++;
     mtm += sizeof(struct Motd);
     mtm += ptr->path ? (strlen(ptr->path) + 1) : 0;
+    mtm += ptr->hostmask ? (strlen(ptr->hostmask) + 1) : 0;
   }
 
   for (cache = MotdList.cachelist; cache; cache = cache->next)
   {
     mtc++;
     mtcm += sizeof(struct MotdCache) + (MOTD_LINESIZE * (cache->count - 1));
+    mtcm += cache->path ? (strlen(cache->path) + 1) : 0;
   }
 
   if (MotdList.freelist)


### PR DESCRIPTION
… bytes for ptr->hostmask and cache->path