### PR TITLE
Switch from "NOTICE AUTH" to "NOTICE *".

### DIFF
--- a/doc/readme.iauth
+++ b/doc/readme.iauth
@@ -434,7 +434,7 @@ Example: C 5 192.168.1.10 23367 :In which year did Columbus sail the ocean blue?
 States: REGISTER, HURRY
 Next State: -
 Comments: Indicates that the challenge string should be sent to the
-  specified user, for example via NOTICE AUTH :*** <challenge string>.
+  specified user, for example via NOTICE * :*** <challenge string>.
   The client responds by sending PASS :<response>, which should be
   relayed via the P server message.  This requires that the A policy
   be in effect.

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -116,16 +116,16 @@ static struct {
   unsigned int length;
 } HeaderMessages [] = {
 #define MSG(STR) { STR, sizeof(STR) - 1 }
-  MSG("NOTICE AUTH :*** Looking up your hostname\r\n"),
-  MSG("NOTICE AUTH :*** Found your hostname\r\n"),
-  MSG("NOTICE AUTH :*** Couldn't look up your hostname\r\n"),
-  MSG("NOTICE AUTH :*** Checking Ident\r\n"),
-  MSG("NOTICE AUTH :*** Got ident response\r\n"),
-  MSG("NOTICE AUTH :*** No ident response\r\n"),
-  MSG("NOTICE AUTH :*** \r\n"),
-  MSG("NOTICE AUTH :*** Your forward and reverse DNS do not match, "
+  MSG("NOTICE * :*** Looking up your hostname\r\n"),
+  MSG("NOTICE * :*** Found your hostname\r\n"),
+  MSG("NOTICE * :*** Couldn't look up your hostname\r\n"),
+  MSG("NOTICE * :*** Checking Ident\r\n"),
+  MSG("NOTICE * :*** Got ident response\r\n"),
+  MSG("NOTICE * :*** No ident response\r\n"),
+  MSG("NOTICE * :*** \r\n"),
+  MSG("NOTICE * :*** Your forward and reverse DNS do not match, "
     "ignoring hostname.\r\n"),
-  MSG("NOTICE AUTH :*** Invalid hostname\r\n")
+  MSG("NOTICE * :*** Invalid hostname\r\n")
 #undef MSG
 };
 
@@ -2192,7 +2192,7 @@ static int iauth_cmd_challenge(struct IAuth *iauth, struct Client *cli,
 			       int parc, char **params)
 {
   if (!EmptyString(params[0]))
-    sendrawto_one(cli, "NOTICE AUTH :*** %s", params[0]);
+    sendrawto_one(cli, "NOTICE * :*** %s", params[0]);
   return 0;
 }
 


### PR DESCRIPTION
This patch changes ircu to match the behaviour of other servers including:

- Charybdis (and forks such as Solanum)
- InspIRCd
- ircd-hybrid
- Nefarious
- ngircd
- UnrealIRCd

`*` is a better target for these notices as it is not a valid nickname and therefore there's no potential for clients to confuse it with a real message target.