### PR TITLE
Use 336/337 instead of 346/347 to reply to 'INVITE' commands

### DIFF
--- a/doc/features.txt
+++ b/doc/features.txt
@@ -178,8 +178,8 @@ INVITE list:
  invite to (ie: an invite to a channel which you haven't joined)
  
  Additional Numerics:
-  RPL_INVITELIST      346
-  RPL_ENDOFINVITELIST 347
+  RPL_INVITELIST      336
+  RPL_ENDOFINVITELIST 337
 
 NICK change:
  Version: Since the dawn of time.

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -255,6 +255,8 @@ extern const struct Numeric* get_error_numeric(int err);
 #define RPL_LISTUSAGE        334        /* Undernet extension */
 /*	RPL_COMMANDSYNTAX    334	   Dalnet */
 /*	RPL_LISTSYNTAX	     334	   unreal */
+#define RPL_INVITELIST       336        /* ircd-hybrid extension */
+#define RPL_ENDOFINVITELIST  337        /* ircd-hybrid extension */
 /*      RPL_CHANPASSOK       338           IRCnet extension (?)*/
 #define	RPL_WHOISACTUALLY    338	/* Undernet extension, dalnet */
 /*	RPL_BADCHANPASS	     339           IRCnet extension (?) */
@@ -263,8 +265,8 @@ extern const struct Numeric* get_error_numeric(int err);
 /*      RPL_SUMMONING        342           removed from RFC1459 */
 
 #define RPL_ISSUEDINVITE     345        /* Undernet extension */
-#define RPL_INVITELIST       346        /* IRCnet, Undernet extension */
-#define RPL_ENDOFINVITELIST  347        /* IRCnet, Undernet extension */
+#define RPL_INVEXLIST        346        /* Reply to "MODE +I", RFC2812 calls it RPL_INVITELIST */
+#define RPL_ENDOFINVEXLIST   347        /* Reply to "MODE +I", RFC2812 calls it RPL_ENDOFINVITELIST */
 /*      RPL_EXCEPTLIST       348           IRCnet extension */
 /*      RPL_ENDOFEXCEPTLIST  349           IRCnet extension */
 

--- a/ircd/s_err.c
+++ b/ircd/s_err.c
@@ -704,9 +704,9 @@ static Numeric replyTable[] = {
 /* 335 */
   { 0 },
 /* 336 */
-  { 0 },
+  { RPL_INVITELIST, ":%s", "336" },
 /* 337 */
-  { 0 },
+  { RPL_ENDOFINVITELIST, ":End of Invite List", "337" },
 /* 338 */
   { RPL_WHOISACTUALLY, "%s %s@%s %s :Actual user@host, Actual IP", "338" },
 /* 339 */
@@ -724,9 +724,9 @@ static Numeric replyTable[] = {
 /* 345 */
   { RPL_ISSUEDINVITE, "%s %s %s :%s has been invited by %s", "345" },
 /* 346 */
-  { RPL_INVITELIST, ":%s", "346" },
+  { 0 },
 /* 347 */
-  { RPL_ENDOFINVITELIST, ":End of Invite List", "347" },
+  { 0 },
 /* 348 */
   { 0 },
 /* 349 */


### PR DESCRIPTION
RFC2812 defines `RPL_INVITELIST` (346) and `RPL_ENDOFINVITELIST` (347) numerics,
but they are only to be used for replies to 'MODE +I', which stands for
'invite exemption' (though it is, surprisingly, not defined in RFC2812
itself). An they must have two params: the channel and mask
<https://datatracker.ietf.org/doc/html/rfc2812#page-46>.

Instead, the consensus is to use 336 and 337 to reply to parameter-less
INVITE messages; and call these `RPL_INVITELIST`/`RPL_ENDOFINVITELIST`,
while the RFC2812 numerics should be renamed to something like
`RPL_INVEXLIST`/`RPL_ENDOFINVEXLIST` (which ircu2 does not use, so it
does not matter much). See for example:

* https://github.com/inspircd/inspircd/commit/df17d47b6a17ee6214f7f501e3b9d73cb8acd36e
* https://github.com/unrealircd/unrealircd/commit/a11e6df64b9ab8fe27ecbc1300893bf8796dcebc

Thanks