### PR TITLE
fix on line 837 example.conf.

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -128,10 +128,10 @@ Admin {
 # always be allowed.  Otherwise, new clients will be allowed if there
 # are fewer than maxlinks clients in the class, up to a limit of about
 # 4,000,000,000.
-# 
-# <connect freq> applies only to servers, and specifies the frequency 
+#
+# <connect freq> applies only to servers, and specifies the frequency
 # that the server tries to autoconnect. setting this to 0 will cause
-# the server to attempt to connect repeatedly with no delay until the 
+# the server to attempt to connect repeatedly with no delay until the
 # <maximum links> condition is satisfied. This is a Bad Thing(tm).
 # Note that times can be specified as a number, or by giving something
 # like: 1 minutes 20 seconds, or 1*60+20.
@@ -834,7 +834,7 @@ WebIRC {
 # 127.0.0.1 from checks, write "::1" as an except address.
 IPCheck {
   except "::1";
-}
+};
 
 # [features]
 # IRC servers have a large number of options and features.  Most of these


### PR DESCRIPTION
There is a semicolon missing on that line.