### PR TITLE
Var. fixes to CAP implementation.

### DIFF
--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -3561,6 +3561,9 @@ joinbuf_join(struct JoinBuf *jbuf, struct Channel *chan, unsigned int flags)
         CAP_EXTJOIN, _CAP_LAST_CAP, "%H %s :%s", chan,
         IsAccount(jbuf->jb_source) ? cli_account(jbuf->jb_source) : "*",
         cli_info(jbuf->jb_source));
+      if (cli_user(jbuf->jb_source)->away)
+        sendcmdto_capflag_common_channels_butone(jbuf->jb_source, CMD_AWAY, jbuf->jb_connect,
+          CAP_AWAYNOTIFY, _CAP_LAST_CAP, ":%s", cli_user(jbuf->jb_source)->away);
 
       /* send an op, too, if needed */
       if (flags & CHFL_CHANOP && (oplevel < MAXOPLEVEL || !MyUser(jbuf->jb_source)))

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -147,5 +147,8 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
   sendcmdto_capflag_common_channels_butone(acptr, CMD_ACCOUNT, acptr, CAP_ACCOUNTNOTIFY,
                         _CAP_LAST_CAP, "%s", cli_user(acptr)->account);
 
+  if (CapHas(cli_active(acptr), CAP_ACCOUNTNOTIFY))
+    sendcmdto_one(acptr, CMD_ACCOUNT, cli_from(acptr), "%s", cli_user(acptr)->account);
+
   return 0;
 }

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -905,7 +905,7 @@ hide_hostmask(struct Client *cptr, unsigned int flag)
 
   sendcmdto_capflag_common_channels_butone(cptr, CMD_QUIT, cptr, _CAP_LAST_CAP, CAP_CHGHOST, ":Registered");
   sendcmdto_capflag_common_channels_butone(cptr, CMD_CHGHOST, cptr, CAP_CHGHOST, _CAP_LAST_CAP, "%s %s.%s",
-    cli_username(cptr), cli_account(cptr), feature_str(FEAT_HIDDEN_HOST));
+    cli_user(cptr)->username, cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
   ircd_snprintf(0, cli_user(cptr)->host, HOSTLEN, "%s.%s",
                 cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
 


### PR DESCRIPTION
CHGHOST: Fix bug causing unidented usernames not being included. 
AWAY-NOTYF: Sending AWAY message on-join as per IRCv3 specification (thanks to progval). 
ACCOUNT-NOTIFY: Sending ACCOUNT message to the logged in user as per IRCv3 specification.