### PR TITLE
Added support for account flags

### DIFF
--- a/include/struct.h
+++ b/include/struct.h
@@ -24,6 +24,10 @@
  */
 #ifndef INCLUDED_struct_h
 #define INCLUDED_struct_h
+#ifndef INCLUDED_stdint_h
+#include <stdint.h>
+#define INCLUDED_stdint_h
+#endif
 #ifndef INCLUDED_sys_types_h
 #include <sys/types.h>      /* time_t */
 #define INCLUDED_sys_types_h
@@ -83,8 +87,8 @@ struct User {
   char               host[HOSTLEN + 1];       /**< displayed hostname */
   char               realhost[HOSTLEN + 1];   /**< actual hostname */
   char               account[ACCOUNTLEN + 1]; /**< IRC account name */
-  unsigned int	     acc_id;                  /**< IRC account id */
-  unsigned short int acc_flags;               /**< IRC account flags */
+  uint64_t	     acc_id;                  /**< IRC account id */
+  uint64_t           acc_flags;               /**< IRC account flags */
 };
 
 #endif /* INCLUDED_struct_h */

--- a/include/struct.h
+++ b/include/struct.h
@@ -83,7 +83,8 @@ struct User {
   char               host[HOSTLEN + 1];       /**< displayed hostname */
   char               realhost[HOSTLEN + 1];   /**< actual hostname */
   char               account[ACCOUNTLEN + 1]; /**< IRC account name */
-  time_t	     acc_create;              /**< IRC account timestamp */
+  unsigned int	     acc_id;                  /**< IRC account id */
+  unsigned short int acc_flags;               /**< IRC account flags */
 };
 
 #endif /* INCLUDED_struct_h */

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -108,8 +108,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
 	       char* parv[])
 {
   struct Client *acptr;
-  unsigned int acc_id = 0;
-  unsigned short int acc_flags = 0;
+  uint64_t acc_id = 0, acc_flags = 0;
 
   if (parc < 3)
     return need_more_params(sptr, "ACCOUNT");
@@ -137,7 +136,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
         cli_user(acptr)->acc_id != 0 &&
         cli_user(acptr)->acc_id != acc_id)
        return protocol_violation(cptr, "ACCOUNT ID for already registered user %s "
-              "(%d -> %d)", cli_name(acptr),
+              "(%qu -> %qu)", cli_name(acptr),
               cli_user(acptr)->acc_id, acc_id);
   } else {
     /* Client did not already have an account. */
@@ -150,7 +149,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
     if (acc_id) {
       cli_user(acptr)->acc_id = acc_id;
       Debug((DEBUG_DEBUG, "Received account id: account \"%s\", "
-            "id %u", parv[2], cli_user(acptr)->acc_id));
+            "id %qu", parv[2], cli_user(acptr)->acc_id));
     }
 
     ircd_strncpy(cli_user(acptr)->account, parv[2], ACCOUNTLEN);
@@ -163,12 +162,12 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
   if (parc > 4) {
     cli_user(acptr)->acc_flags = acc_flags;
     Debug((DEBUG_DEBUG, "Received account flags: account \"%s\", "
-           "flags %u", parv[2], cli_user(acptr)->acc_flags));
+           "flags %qu", parv[2], cli_user(acptr)->acc_flags));
   }
 
   /* To propagate a 0 flag, we check the param number rather than whether acc_flags is true. */
   sendcmdto_serv_butone(sptr, CMD_ACCOUNT, cptr,
-                        cli_user(acptr)->acc_id ? (parc > 4 ? "%C %s %u %u" : "%C %s %u") : "%C %s",
+                        cli_user(acptr)->acc_id ? (parc > 4 ? "%C %s %qu %qu" : "%C %s %qu") : "%C %s",
                         acptr, cli_user(acptr)->account,
                         cli_user(acptr)->acc_id,
                         cli_user(acptr)->acc_flags);

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -101,6 +101,8 @@
  * parv[0] = sender prefix
  * parv[1] = numeric of client to act on
  * parv[2] = account name (12 characters or less)
+ * parv[3] = account id
+ * parv[4] = account flags
  */
 int ms_account(struct Client* cptr, struct Client* sptr, int parc,
 	       char* parv[])
@@ -117,38 +119,52 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
   if (!(acptr = findNUser(parv[1])))
     return 0; /* Ignore ACCOUNT for a user that QUIT; probably crossed */
 
-  if (IsAccount(acptr))
-    return protocol_violation(cptr, "ACCOUNT for already registered user %s "
-			      "(%s -> %s)", cli_name(acptr),
-			      cli_user(acptr)->account, parv[2]);
+  /* If the client already has an account, we do not accept changes to the account or acc_id. */
+  if (IsAccount(acptr)) {
+    if (strcmp(cli_user(acptr)->account, parv[2]))
+      return protocol_violation(cptr, "ACCOUNT for already registered user %s "
+              "(%s -> %s)", cli_name(acptr),
+              cli_user(acptr)->account, parv[2]);
+    if (cli_user(acptr)->acc_id != 0 && cli_user(acptr)->acc_id != atoi(parv[3]))
+       return protocol_violation(cptr, "ACCOUNT ID for already registered user %s "
+              "(%d -> %d)", cli_name(acptr),
+              cli_user(acptr)->acc_id, atoi(parv[3]));
+  } else {
+    /* Client did not already have an account. */
+    if (strlen(parv[2]) > ACCOUNTLEN)
+      return protocol_violation(cptr,
+                                "Received account (%s) longer than %d for %s; "
+                                "ignoring.",
+                                parv[2], ACCOUNTLEN, cli_name(acptr));
 
-  assert(0 == cli_user(acptr)->account[0]);
+    if (parc > 3) {
+      cli_user(acptr)->acc_id = atoi(parv[3]);
+      Debug((DEBUG_DEBUG, "Received account id: account \"%s\", "
+            "id %u", parv[2], cli_user(acptr)->acc_id));
+    }
 
-  if (strlen(parv[2]) > ACCOUNTLEN)
-    return protocol_violation(cptr,
-                              "Received account (%s) longer than %d for %s; "
-                              "ignoring.",
-                              parv[2], ACCOUNTLEN, cli_name(acptr));
+    ircd_strncpy(cli_user(acptr)->account, parv[2], ACCOUNTLEN);
+    hide_hostmask(acptr, FLAG_ACCOUNT);
 
-  if (parc > 3) {
-    cli_user(acptr)->acc_create = atoi(parv[3]);
-    Debug((DEBUG_DEBUG, "Received timestamped account: account \"%s\", "
-           "timestamp %Tu", parv[2], cli_user(acptr)->acc_create));
+    sendcmdto_capflag_common_channels_butone(acptr, CMD_ACCOUNT, acptr, CAP_ACCOUNTNOTIFY,
+                          _CAP_LAST_CAP, "%s", cli_user(acptr)->account);
+
+    if (CapHas(cli_active(acptr), CAP_ACCOUNTNOTIFY))
+      sendcmdto_one(acptr, CMD_ACCOUNT, cli_from(acptr), "%s", cli_user(acptr)->account);
   }
 
-  ircd_strncpy(cli_user(acptr)->account, parv[2], ACCOUNTLEN);
-  hide_hostmask(acptr, FLAG_ACCOUNT);
+  if (parc > 4) {
+    cli_user(acptr)->acc_flags = atoi(parv[4]);
+    Debug((DEBUG_DEBUG, "Received account flags: account \"%s\", "
+           "flags %u", parv[2], cli_user(acptr)->acc_flags));
+  }
 
+  /* To propagate a 0 flag, we check the param number rather than whether acc_flags is true. */
   sendcmdto_serv_butone(sptr, CMD_ACCOUNT, cptr,
-                        cli_user(acptr)->acc_create ? "%C %s %Tu" : "%C %s",
+                        cli_user(acptr)->acc_id ? (parc > 4 ? "%C %s %u %u" : "%C %s %u") : "%C %s",
                         acptr, cli_user(acptr)->account,
-                        cli_user(acptr)->acc_create);
-
-  sendcmdto_capflag_common_channels_butone(acptr, CMD_ACCOUNT, acptr, CAP_ACCOUNTNOTIFY,
-                        _CAP_LAST_CAP, "%s", cli_user(acptr)->account);
-
-  if (CapHas(cli_active(acptr), CAP_ACCOUNTNOTIFY))
-    sendcmdto_one(acptr, CMD_ACCOUNT, cli_from(acptr), "%s", cli_user(acptr)->account);
+                        cli_user(acptr)->acc_id,
+                        cli_user(acptr)->acc_flags);
 
   return 0;
 }

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -2129,11 +2129,18 @@ static int iauth_cmd_done_account(struct IAuth *iauth, struct Client *cli,
     sendto_iauth(cli, "E Invalid :Account parameter too long");
     return 0;
   }
-  /* If account has a creation timestamp, use it. */
+  /* If account has an id, use it. */
   assert(cli_user(cli) != NULL);
   if (params[0][len] == ':') {
-    cli_user(cli)->acc_create = strtoul(params[0] + len + 1, NULL, 10);
+    cli_user(cli)->acc_id = strtoul(params[0] + len + 1, NULL, 10);
     params[0][len] = '\0';
+
+    /* If account has flags, use it. */
+    char *flags_start = strchr(params[0] + len + 1, ':');
+    if (flags_start != NULL) {
+        cli_user(cli)->acc_flags = strtoul(flags_start + 1, NULL, 10);
+        *flags_start = '\0';
+    }
   }
 
   /* Copy account name to User structure. */

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1151,7 +1151,7 @@ int set_user_mode(struct Client *cptr, struct Client *sptr, int parc,
         len = (id++) - account;
 	      cli_user(sptr)->acc_id = atoi(id);
 	      Debug((DEBUG_DEBUG, "Received account id in user mode; "
-	        "account \"%s\", id %u", account,
+	        "account \"%s\", id %qu", account,
 	        cli_user(sptr)->acc_id));
 
         /* Check for account flags */
@@ -1160,7 +1160,7 @@ int set_user_mode(struct Client *cptr, struct Client *sptr, int parc,
             cli_user(sptr)->acc_flags = atoi(flags + 1);
             // Null-terminate the account string before flags.
             *flags = '\0';
-            Debug((DEBUG_DEBUG, "Received account flags; account \"%s\", flags %u",
+            Debug((DEBUG_DEBUG, "Received account flags; account \"%s\", flags %qu",
                     account, cli_user(sptr)->acc_flags));
         }
       }
@@ -1235,18 +1235,18 @@ char *umode_str(struct Client *cptr)
     if (cli_user(cptr)->acc_id) {
       char nbuf[30];
       Debug((DEBUG_DEBUG, "Sending account id in user mode for "
-	     "account \"%s\"; id %u", cli_user(cptr)->account,
+	     "account \"%s\"; id %qu", cli_user(cptr)->account,
 	     cli_user(cptr)->acc_id));
 
       if (cli_user(cptr)->acc_flags) {
       Debug((DEBUG_DEBUG, "Sending account flags in user mode for "
-	     "account \"%s\"; flags %u", cli_user(cptr)->account,
+	     "account \"%s\"; flags %qu", cli_user(cptr)->account,
 	     cli_user(cptr)->acc_flags));
 
-        ircd_snprintf(0, t = nbuf, sizeof(nbuf), ":%u:%u",
+        ircd_snprintf(0, t = nbuf, sizeof(nbuf), ":%qu:%qu",
                       cli_user(cptr)->acc_id, cli_user(cptr)->acc_flags);
       } else {
-        ircd_snprintf(0, t = nbuf, sizeof(nbuf), ":%u",
+        ircd_snprintf(0, t = nbuf, sizeof(nbuf), ":%qu",
                       cli_user(cptr)->acc_id);
       }
       m--; /* back up over previous nul-termination */

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -904,13 +904,13 @@ hide_hostmask(struct Client *cptr, unsigned int flag)
     return 0;
 
   sendcmdto_capflag_common_channels_butone(cptr, CMD_QUIT, cptr, _CAP_LAST_CAP, CAP_CHGHOST, ":Registered");
-  sendcmdto_capflag_common_channels_butone(cptr, CMD_CHGHOST, cptr, CAP_CHGHOST, _CAP_LAST_CAP, "%s %s.%s",
+  sendcmdto_capflag_common_channels_butone(cptr, CMD_CHGHOST, NULL, CAP_CHGHOST, _CAP_LAST_CAP, "%s %s.%s",
     cli_user(cptr)->username, cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
   ircd_snprintf(0, cli_user(cptr)->host, HOSTLEN, "%s.%s",
                 cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
 
   /* ok, the client is now fully hidden, so let them know -- hikari */
-  if (MyConnect(cptr))
+  if (MyConnect(cptr) && !CapHas(cli_active(cptr), CAP_CHGHOST))
    send_reply(cptr, RPL_HOSTHIDDEN, cli_user(cptr)->host);
 
   /*

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -568,7 +568,10 @@ void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *c
     }
   }
 
-  if (MyConnect(from) && from != one)
+  if (MyConnect(from)
+      && from != one
+      && (require == _CAP_LAST_CAP || CapHas(cli_active(from), require))
+      && (forbid == _CAP_LAST_CAP || !CapHas(cli_active(from), forbid)))
     send_buffer(from, mb, 0);
 
   msgq_clean(mb);


### PR DESCRIPTION
* Added support for passing of account flags in the AC (and corresponding N +r) messages.
* Fix in send.c causing capflag messages being sent to from even if flag rule is not met. 