### PR TITLE
Fixes to cap handling

### DIFF
--- a/include/capab.h
+++ b/include/capab.h
@@ -44,18 +44,24 @@
 	_CAP(EXTJOIN, FEAT_CAP_EXTJOIN, 0, "extended-join"), \
 	_CAP(INVITENOTIFY, FEAT_CAP_INVITENOTIFY, 0, "invite-notify")
 
-/** Client capabilities */
+/** Client capabilities, counting by index. */
 enum Capab {
-#define _CAP(cap, config, flags, name)	CAP_ ## cap
+#define _CAP(cap, config, flags, name)	E_CAP_ ## cap
   CAPLIST,
 #undef _CAP
-  _CAP_LAST_CAP
+  _E_CAP_LAST_CAP
 };
 
-DECLARE_FLAGSET(CapSet, _CAP_LAST_CAP);
+/** Client capabilities, bit mask version. */
+enum CapabBits {
+#define _CAP(cap, config, flags, name) CAP_ ## cap = 1u << E_CAP_ ## cap
+  CAPLIST,
+#undef _CAP
+  _CAP_LAST_CAP = 1u << _E_CAP_LAST_CAP
+};
 
-#define CapHas(cs, cap)	FlagHas(cs, cap)
-#define CapSet(cs, cap)	FlagSet(cs, cap)
-#define CapClr(cs, cap)	FlagClr(cs, cap)
+#define CapHas(cs, cap)	(cs & cap)
+#define CapSet(cs, cap)	(cs |= cap)
+#define CapClr(cs, cap)	(cs &= ~cap)
 
 #endif /* INCLUDED_capab_h */

--- a/include/client.h
+++ b/include/client.h
@@ -65,6 +65,9 @@ struct AuthRequest;
  * source file, or in the source file itself (when only used in that file).
  */
 
+/** Value to hold a set of capability bits (from capab.h). */
+typedef unsigned short capset_t;
+
 /** Single element in a flag bitset array. */
 typedef unsigned long flagpage_t;
 
@@ -229,8 +232,8 @@ struct Connection
   struct Timer        con_proc;      /**< process latent messages from
                                       client */
   struct Privs        con_privs;     /**< Oper privileges */
-  struct CapSet       con_capab;     /**< Client capabilities (from us) */
-  struct CapSet       con_active;    /**< Active capabilities (to us) */
+  capset_t            con_capab;     /**< Client capabilities (from us) */
+  capset_t            con_active;    /**< Active capabilities (to us) */
   struct AuthRequest* con_auth;      /**< Auth request for client */
   const struct wline* con_wline;     /**< WebIRC authorization for client */
 };
@@ -460,9 +463,9 @@ struct Client {
 /** Get the oper privilege set for the connection. */
 #define con_privs(con)          (&(con)->con_privs)
 /** Get the peer's capabilities for the connection. */
-#define con_capab(con)          (&(con)->con_capab)
+#define con_capab(con)          ((con)->con_capab)
 /** Get the active capabilities for the connection. */
-#define con_active(con)         (&(con)->con_active)
+#define con_active(con)         ((con)->con_active)
 /** Get the auth request for the connection. */
 #define con_auth(con)		((con)->con_auth)
 /** Get the WebIRC block (if any) used by the connection. */

--- a/include/send.h
+++ b/include/send.h
@@ -13,6 +13,10 @@
 #define INCLUDED_time_h
 #endif
 
+#ifndef INCLUDED_client_h
+#include "client.h" /* capset_t */
+#endif
+
 struct Channel;
 struct Client;
 struct DBuf;
@@ -67,15 +71,16 @@ extern void sendcmdto_capflag_common_channels_butone(struct Client *from,
 						     const char *cmd,
 						     const char *tok,
 						     struct Client *one,
-						     int require,
-						     int forbid,
+						     capset_t require,
+						     capset_t forbid,
 						     const char *pattern, ...);
 
 /* Send command to all channel users on this server matching or not matching a capability flag */
 void sendcmdto_capflag_channel_butserv_butone(struct Client *from, const char *cmd,
 					      const char *tok, struct Channel *to,
 					      struct Client *one, unsigned int skip,
-					      int require, int forbid, const char *pattern, ...);
+					      capset_t require, capset_t forbid,
+					      const char *pattern, ...);
 
 /* Send command to all channel users on this server */
 extern void sendcmdto_channel_butserv_butone(struct Client *from,
@@ -100,6 +105,18 @@ extern void sendcmdto_channel_butone(struct Client *from, const char *cmd,
 				     const char *tok, struct Channel *to,
 				     struct Client *one, unsigned int skip,
 				     const char *pattern, ...);
+
+
+/* Send JOIN to all local channel users matching or not matching capability flags */
+extern void sendjointo_channel_butserv(struct Client *from,
+				       struct Channel *chptr,
+				       capset_t require,
+				       capset_t forbid);
+
+/* Send JOIN to a single user */
+extern void sendjointo_one(struct Client *from,
+			   struct Channel *chptr,
+			   struct Client *one);
 
 #define SKIP_DEAF	0x01	/**< skip users that are +d */
 #define SKIP_BURST	0x02	/**< skip users that are bursting */

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -3556,12 +3556,7 @@ joinbuf_join(struct JoinBuf *jbuf, struct Channel *chan, unsigned int flags)
 
     if (!((chan->mode.mode & MODE_DELJOINS) && !(flags & CHFL_VOICED_OR_OPPED))) {
       /* Send the notification to the channel */
-      sendcmdto_capflag_channel_butserv_butone(jbuf->jb_source, CMD_JOIN, chan, NULL, 0,
-        0, CAP_EXTJOIN, "%H", chan);
-      sendcmdto_capflag_channel_butserv_butone(jbuf->jb_source, CMD_JOIN, chan, NULL, 0,
-        CAP_EXTJOIN, 0, "%H %s :%s", chan,
-        IsAccount(jbuf->jb_source) ? cli_account(jbuf->jb_source) : "*",
-        cli_info(jbuf->jb_source));
+      sendjointo_channel_butserv(jbuf->jb_source, chan, 0, 0);
       if (cli_user(jbuf->jb_source)->away)
         sendcmdto_capflag_common_channels_butone(jbuf->jb_source, CMD_AWAY, jbuf->jb_connect,
           CAP_AWAYNOTIFY, 0, ":%s", cli_user(jbuf->jb_source)->away);
@@ -3572,7 +3567,7 @@ joinbuf_join(struct JoinBuf *jbuf, struct Channel *chan, unsigned int flags)
                                          CMD_MODE, chan, NULL, 0, "%H +o %C",
 					 chan, jbuf->jb_source);
     } else if (MyUser(jbuf->jb_source))
-      sendcmdto_one(jbuf->jb_source, CMD_JOIN, jbuf->jb_source, ":%H", chan);
+      sendjointo_one(jbuf->jb_source, chan, jbuf->jb_source);
   }
 
   if (jbuf->jb_type == JOINBUF_TYPE_PARTALL ||
@@ -3656,13 +3651,7 @@ int IsInvited(struct Client* cptr, const void* chptr)
 void RevealDelayedJoin(struct Membership *member)
 {
   ClearDelayedJoin(member);
-  sendcmdto_capflag_channel_butserv_butone(member->user, CMD_JOIN, member->channel, NULL, 0,
-        0, CAP_EXTJOIN, "%H", member->channel);
-  sendcmdto_capflag_channel_butserv_butone(member->user, CMD_JOIN, member->channel, NULL, 0,
-        CAP_EXTJOIN, 0, "%H %s :%s", member->channel,
-        IsAccount(member->user) ? cli_account(member->user) : "*",
-        cli_info(member->user));
-
+  sendjointo_channel_butserv(member->user, member->channel, 0, 0);
   CheckDelayedJoins(member->channel);
 }
 

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -3557,14 +3557,14 @@ joinbuf_join(struct JoinBuf *jbuf, struct Channel *chan, unsigned int flags)
     if (!((chan->mode.mode & MODE_DELJOINS) && !(flags & CHFL_VOICED_OR_OPPED))) {
       /* Send the notification to the channel */
       sendcmdto_capflag_channel_butserv_butone(jbuf->jb_source, CMD_JOIN, chan, NULL, 0,
-        _CAP_LAST_CAP, CAP_EXTJOIN, "%H", chan);
+        0, CAP_EXTJOIN, "%H", chan);
       sendcmdto_capflag_channel_butserv_butone(jbuf->jb_source, CMD_JOIN, chan, NULL, 0,
-        CAP_EXTJOIN, _CAP_LAST_CAP, "%H %s :%s", chan,
+        CAP_EXTJOIN, 0, "%H %s :%s", chan,
         IsAccount(jbuf->jb_source) ? cli_account(jbuf->jb_source) : "*",
         cli_info(jbuf->jb_source));
       if (cli_user(jbuf->jb_source)->away)
         sendcmdto_capflag_common_channels_butone(jbuf->jb_source, CMD_AWAY, jbuf->jb_connect,
-          CAP_AWAYNOTIFY, _CAP_LAST_CAP, ":%s", cli_user(jbuf->jb_source)->away);
+          CAP_AWAYNOTIFY, 0, ":%s", cli_user(jbuf->jb_source)->away);
 
       /* send an op, too, if needed */
       if (flags & CHFL_CHANOP && (oplevel < MAXOPLEVEL || !MyUser(jbuf->jb_source)))
@@ -3657,9 +3657,9 @@ void RevealDelayedJoin(struct Membership *member)
 {
   ClearDelayedJoin(member);
   sendcmdto_capflag_channel_butserv_butone(member->user, CMD_JOIN, member->channel, NULL, 0,
-        _CAP_LAST_CAP, CAP_EXTJOIN, "%H", member->channel);
+        0, CAP_EXTJOIN, "%H", member->channel);
   sendcmdto_capflag_channel_butserv_butone(member->user, CMD_JOIN, member->channel, NULL, 0,
-        CAP_EXTJOIN, _CAP_LAST_CAP, "%H %s :%s", member->channel,
+        CAP_EXTJOIN, 0, "%H %s :%s", member->channel,
         IsAccount(member->user) ? cli_account(member->user) : "*",
         cli_info(member->user));
 

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -3652,6 +3652,9 @@ void RevealDelayedJoin(struct Membership *member)
 {
   ClearDelayedJoin(member);
   sendjointo_channel_butserv(member->user, member->channel, 0, 0);
+  if (cli_user(member->user)->away)
+    sendcmdto_capflag_channel_butserv_butone(member->user, CMD_AWAY, member->channel,
+      NULL, 0, CAP_AWAYNOTIFY, 0, ":%s", cli_user(member->user)->away);
   CheckDelayedJoins(member->channel);
 }
 

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -153,10 +153,9 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
     }
 
     ircd_strncpy(cli_user(acptr)->account, parv[2], ACCOUNTLEN);
-    hide_hostmask(acptr, FLAG_ACCOUNT);
-
     sendcmdto_capflag_common_channels_butone(acptr, CMD_ACCOUNT, NULL, CAP_ACCOUNTNOTIFY,
                           0, "%s", cli_user(acptr)->account);
+    hide_hostmask(acptr, FLAG_ACCOUNT);
   }
 
   if (parc > 4) {

--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -156,7 +156,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
     hide_hostmask(acptr, FLAG_ACCOUNT);
 
     sendcmdto_capflag_common_channels_butone(acptr, CMD_ACCOUNT, NULL, CAP_ACCOUNTNOTIFY,
-                          _CAP_LAST_CAP, "%s", cli_user(acptr)->account);
+                          0, "%s", cli_user(acptr)->account);
   }
 
   if (parc > 4) {

--- a/ircd/m_away.c
+++ b/ircd/m_away.c
@@ -164,14 +164,14 @@ int m_away(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
     if (!was_away)
     {
       sendcmdto_serv_butone(sptr, CMD_AWAY, cptr, ":%s", away_message);
-      sendcmdto_capflag_common_channels_butone(sptr, CMD_AWAY, cptr, CAP_AWAYNOTIFY, _CAP_LAST_CAP, ":%s", away_message);
+      sendcmdto_capflag_common_channels_butone(sptr, CMD_AWAY, cptr, CAP_AWAYNOTIFY, 0, ":%s", away_message);
     }
 
     send_reply(sptr, RPL_NOWAWAY);
   }
   else {
     sendcmdto_serv_butone(sptr, CMD_AWAY, cptr, "");
-    sendcmdto_capflag_common_channels_butone(sptr, CMD_AWAY, cptr, CAP_AWAYNOTIFY, _CAP_LAST_CAP, "");
+    sendcmdto_capflag_common_channels_butone(sptr, CMD_AWAY, cptr, CAP_AWAYNOTIFY, 0, "");
     send_reply(sptr, RPL_UNAWAY);
   }
   return 0;

--- a/ircd/m_burst.c
+++ b/ircd/m_burst.c
@@ -543,8 +543,8 @@ int ms_burst(struct Client *cptr, struct Client *sptr, int parc, char *parv[])
 	  if (!(member = find_member_link(chptr, acptr)))
 	  {
 	    add_user_to_channel(chptr, acptr, current_mode, oplevel);
-            if (!(current_mode & CHFL_DELAYED))
-              sendcmdto_channel_butserv_butone(acptr, CMD_JOIN, chptr, NULL, 0, "%H", chptr);
+	    if (!(current_mode & CHFL_DELAYED))
+	      sendjointo_channel_butserv(acptr, chptr, 0, 0);
 	  }
 	  else
 	  {

--- a/ircd/m_burst.c
+++ b/ircd/m_burst.c
@@ -543,8 +543,12 @@ int ms_burst(struct Client *cptr, struct Client *sptr, int parc, char *parv[])
 	  if (!(member = find_member_link(chptr, acptr)))
 	  {
 	    add_user_to_channel(chptr, acptr, current_mode, oplevel);
-	    if (!(current_mode & CHFL_DELAYED))
+	    if (!(current_mode & CHFL_DELAYED)) {
 	      sendjointo_channel_butserv(acptr, chptr, 0, 0);
+              if (cli_user(acptr)->away)
+                sendcmdto_capflag_channel_butserv_butone(acptr, CMD_AWAY, chptr,
+                  NULL, 0, CAP_AWAYNOTIFY, 0, ":%s", cli_user(acptr)->away);
+              }
 	  }
 	  else
 	  {

--- a/ircd/m_cap.c
+++ b/ircd/m_cap.c
@@ -53,7 +53,7 @@ static struct capabilities {
   int namelen;
 } capab_list[] = {
 #define _CAP(cap, config, flags, name)      \
-	{ CAP_ ## cap, #cap, (config), (flags), (name), sizeof(name) - 1 }
+	{ E_CAP_ ## cap, #cap, (config), (flags), (name), sizeof(name) - 1 }
   CAPLIST
 #undef _CAP
 };
@@ -138,8 +138,8 @@ find_cap(const char **caplist_p, int *neg_p)
  * @param[in] subcmd Name of capability subcommand.
  */
 static int
-send_caplist(struct Client *sptr, const struct CapSet *set,
-             const struct CapSet *rem, const char *subcmd)
+send_caplist(struct Client *sptr, capset_t set,
+             capset_t rem, const char *subcmd)
 {
   char capbuf[BUFSIZE] = "", pfx[16];
   struct MsgBuf *mb;
@@ -209,9 +209,9 @@ cap_req(struct Client *sptr, const char *caplist)
 {
   const char *cl = caplist;
   struct capabilities *cap;
-  struct CapSet set, rem;
-  struct CapSet cs = *cli_capab(sptr); /* capability set */
-  struct CapSet as = *cli_active(sptr); /* active set */
+  capset_t set = 0, rem = 0;
+  capset_t cs = cli_capab(sptr); /* capability set */
+  capset_t as = cli_active(sptr); /* active set */
   int neg;
 
   if (IsUserPort(sptr)) /* registration hasn't completed; suspend it... */
@@ -229,24 +229,24 @@ cap_req(struct Client *sptr, const char *caplist)
     }
 
     if (neg) { /* set or clear the capability... */
-      CapSet(&rem, cap->cap);
-      CapClr(&set, cap->cap);
-      CapClr(&cs, cap->cap);
+      CapSet(rem, cap->cap);
+      CapClr(set, cap->cap);
+      CapClr(cs, cap->cap);
       if (!(cap->flags & CAPFL_PROTO))
-	CapClr(&as, cap->cap);
+	CapClr(as, cap->cap);
     } else {
-      CapClr(&rem, cap->cap);
-      CapSet(&set, cap->cap);
-      CapSet(&cs, cap->cap);
+      CapClr(rem, cap->cap);
+      CapSet(set, cap->cap);
+      CapSet(cs, cap->cap);
       if (!(cap->flags & CAPFL_PROTO))
-	CapSet(&as, cap->cap);
+	CapSet(as, cap->cap);
     }
   }
 
   /* Notify client of accepted changes and copy over results. */
-  send_caplist(sptr, &set, &rem, "ACK");
-  *cli_capab(sptr) = cs;
-  *cli_active(sptr) = as;
+  send_caplist(sptr, set, rem, "ACK");
+  cli_capab(sptr) = cs;
+  cli_active(sptr) = as;
 
   return 0;
 }
@@ -284,24 +284,23 @@ cap_ack(struct Client *sptr, const char *caplist)
 static int
 cap_clear(struct Client *sptr, const char *caplist)
 {
-  struct CapSet cleared;
+  capset_t cleared = 0;
   struct capabilities *cap;
   unsigned int ii;
 
   /* XXX: If we ever add a capab list sorted by capab value, it would
    * be good cache-wise to use it here. */
-  memset(&cleared, 0, sizeof(cleared));
   for (ii = 0; ii < CAPAB_LIST_LEN; ++ii) {
     cap = &capab_list[ii];
     /* Only clear active non-sticky capabilities. */
     if (!HasCap(sptr, cap->cap) || (cap->flags & CAPFL_STICKY))
       continue;
-    CapSet(&cleared, cap->cap);
+    CapSet(cleared, cap->cap);
     CapClr(cli_capab(sptr), cap->cap);
     if (!(cap->flags & CAPFL_PROTO))
       CapClr(cli_active(sptr), cap->cap);
   }
-  send_caplist(sptr, 0, &cleared, "ACK");
+  send_caplist(sptr, 0, cleared, "ACK");
 
   return 0;
 }

--- a/ircd/m_cap.c
+++ b/ircd/m_cap.c
@@ -199,7 +199,7 @@ send_caplist(struct Client *sptr, const struct CapSet *set,
 static int
 cap_ls(struct Client *sptr, const char *caplist)
 {
-  if (IsUnknown(sptr)) /* registration hasn't completed; suspend it... */
+  if (IsUserPort(sptr)) /* registration hasn't completed; suspend it... */
     auth_cap_start(cli_auth(sptr));
   return send_caplist(sptr, 0, 0, "LS"); /* send list of capabilities */
 }
@@ -214,7 +214,7 @@ cap_req(struct Client *sptr, const char *caplist)
   struct CapSet as = *cli_active(sptr); /* active set */
   int neg;
 
-  if (IsUnknown(sptr)) /* registration hasn't completed; suspend it... */
+  if (IsUserPort(sptr)) /* registration hasn't completed; suspend it... */
     auth_cap_start(cli_auth(sptr));
 
   memset(&set, 0, sizeof(set));
@@ -309,7 +309,7 @@ cap_clear(struct Client *sptr, const char *caplist)
 static int
 cap_end(struct Client *sptr, const char *caplist)
 {
-  if (!IsUnknown(sptr)) /* registration has completed... */
+  if (!IsUserPort(sptr)) /* registration has completed... */
     return 0; /* so just ignore the message... */
 
   return auth_cap_done(cli_auth(sptr));

--- a/ircd/m_destruct.c
+++ b/ircd/m_destruct.c
@@ -153,14 +153,7 @@ int ms_destruct(struct Client* cptr, struct Client* sptr, int parc, char* parv[]
 
     /* Next, send JOINs for all members. */
     for (member = chptr->members; member; member = member->next_member)
-    {
-      if (CapHas(cli_active(member->user), CAP_EXTJOIN))
-        sendcmdto_one(member->user, CMD_JOIN, cptr,
-        "%H %s :%s", chptr, IsAccount(cptr) ? cli_account(cptr) : "*",
-        cli_info(cptr));
-      else
-        sendcmdto_one(member->user, CMD_JOIN, cptr, "%H", chptr);
-    }
+      sendjointo_one(member->user, chptr, cptr);
 
     /* Build MODE strings. We use MODEBUF_DEST_BOUNCE with MODE_DEL to assure
        that the resulting MODEs are only sent upstream. */

--- a/ircd/m_invite.c
+++ b/ircd/m_invite.c
@@ -189,14 +189,14 @@ int m_invite(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
      */
     sendcmdto_capflag_channel_butserv_butone(sptr, CMD_INVITE,
                                              chptr, sptr, SKIP_NONOPS,
-                                             CAP_INVITENOTIFY, _CAP_LAST_CAP,
+                                             CAP_INVITENOTIFY, 0,
                                              "%C %H", acptr, chptr);
 
     if (feature_bool(FEAT_ANNOUNCE_INVITES)) {
       /* Announce to channel operators without CAP_INVITENOTIFY enabled. */
       sendcmdto_capflag_channel_butserv_butone(&his, get_error_numeric(RPL_ISSUEDINVITE)->str,
                                                NULL, chptr, sptr, SKIP_NONOPS,
-                                               _CAP_LAST_CAP, CAP_INVITENOTIFY,
+                                               0, CAP_INVITENOTIFY,
                                                "%H %C %C :%C has been invited by %C",
                                                chptr, acptr, sptr, acptr, sptr);
       /* Announce to servers with channel operators. */
@@ -300,14 +300,14 @@ int ms_invite(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
   /* Announce to channel operators with CAP_NOTIFY enabled. */
   sendcmdto_capflag_channel_butserv_butone(sptr, CMD_INVITE,
                                            chptr, sptr, SKIP_NONOPS,
-                                           CAP_INVITENOTIFY, _CAP_LAST_CAP,
+                                           CAP_INVITENOTIFY, 0,
                                            "%C %H", acptr, chptr);
 
   if (feature_bool(FEAT_ANNOUNCE_INVITES)) {
     /* Announce to channel operators without CAP_NOTIFY enabled. */
     sendcmdto_capflag_channel_butserv_butone(&his, get_error_numeric(RPL_ISSUEDINVITE)->str,
                                              NULL, chptr, sptr, SKIP_NONOPS,
-                                             _CAP_LAST_CAP, CAP_INVITENOTIFY,
+                                             0, CAP_INVITENOTIFY,
                                              "%H %C %C :%C has been invited by %C",
                                              chptr, acptr, sptr, acptr, sptr);
     /* Announce to servers with channel operators. */

--- a/ircd/m_kick.c
+++ b/ircd/m_kick.c
@@ -164,7 +164,7 @@ int m_kick(struct Client *cptr, struct Client *sptr, int parc, char *parv[])
      * the kicking and the victim */
     if (MyUser(who))
       sendcmdto_one(sptr, CMD_KICK, who, "%H %C :%s", chptr, who, comment);
-    sendcmdto_one(who, CMD_JOIN, sptr, "%H", chptr);
+    sendjointo_one(who, chptr, sptr);
     sendcmdto_one(sptr, CMD_KICK, sptr, "%H %C :%s", chptr, who, comment);
     CheckDelayedJoins(chptr);
   } else
@@ -239,7 +239,7 @@ int ms_kick(struct Client *cptr, struct Client *sptr, int parc, char *parv[])
     sendto_opmask_butone(0, SNO_HACK2, "HACK: %C KICK %H %C %s", sptr, chptr,
 			 who, comment);
 
-    sendcmdto_one(who, CMD_JOIN, cptr, "%H", chptr);
+    sendjointo_one(who, chptr, cptr);
 
     /* Reop/revoice member */
     if (IsChanOp(member) || HasVoice(member)) {

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -903,8 +903,8 @@ hide_hostmask(struct Client *cptr, unsigned int flag)
   if (!HasFlag(cptr, FLAG_HIDDENHOST) || !HasFlag(cptr, FLAG_ACCOUNT))
     return 0;
 
-  sendcmdto_capflag_common_channels_butone(cptr, CMD_QUIT, cptr, _CAP_LAST_CAP, CAP_CHGHOST, ":Registered");
-  sendcmdto_capflag_common_channels_butone(cptr, CMD_CHGHOST, NULL, CAP_CHGHOST, _CAP_LAST_CAP, "%s %s.%s",
+  sendcmdto_capflag_common_channels_butone(cptr, CMD_QUIT, cptr, 0, CAP_CHGHOST, ":Registered");
+  sendcmdto_capflag_common_channels_butone(cptr, CMD_CHGHOST, NULL, CAP_CHGHOST, 0, "%s %s.%s",
     cli_user(cptr)->username, cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
   ircd_snprintf(0, cli_user(cptr)->host, HOSTLEN, "%s.%s",
                 cli_user(cptr)->account, feature_str(FEAT_HIDDEN_HOST));
@@ -924,14 +924,14 @@ hide_hostmask(struct Client *cptr, unsigned int flag)
     /* Send a JOIN unless the user's join has been delayed. */
     if (!IsDelayedJoin(chan))
       sendcmdto_capflag_channel_butserv_butone(cptr, CMD_JOIN, chan->channel, cptr, 0,
-                                         _CAP_LAST_CAP, CAP_CHGHOST, "%H", chan->channel);
+                                         0, CAP_CHGHOST, "%H", chan->channel);
     if (IsChanOp(chan) && HasVoice(chan))
       sendcmdto_capflag_channel_butserv_butone(&his, CMD_MODE, chan->channel, cptr, 0,
-                                       _CAP_LAST_CAP, CAP_CHGHOST, "%H +ov %C %C", chan->channel, cptr,
+                                       0, CAP_CHGHOST, "%H +ov %C %C", chan->channel, cptr,
                                        cptr);
     else if (IsChanOp(chan) || HasVoice(chan))
       sendcmdto_capflag_channel_butserv_butone(&his, CMD_MODE, chan->channel, cptr, 0,
-        _CAP_LAST_CAP, CAP_CHGHOST, "%H +%c %C", chan->channel, IsChanOp(chan) ? 'o' : 'v', cptr);
+        0, CAP_CHGHOST, "%H +%c %C", chan->channel, IsChanOp(chan) ? 'o' : 'v', cptr);
   }
   return 0;
 }

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -923,8 +923,12 @@ hide_hostmask(struct Client *cptr, unsigned int flag)
       continue;
     /* Send a JOIN unless the user's join has been delayed. */
     if (!IsDelayedJoin(chan))
-      sendcmdto_capflag_channel_butserv_butone(cptr, CMD_JOIN, chan->channel, cptr, 0,
-                                         0, CAP_CHGHOST, "%H", chan->channel);
+    {
+      sendjointo_channel_butserv(cptr, chan->channel, 0, CAP_CHGHOST);
+      if (cli_user(cptr)->away)
+        sendcmdto_capflag_channel_butserv_butone(cptr, CMD_AWAY, chan->channel,
+          NULL, 0, CAP_AWAYNOTIFY, CAP_CHGHOST, ":%s", cli_user(cptr)->away);
+    }
     if (IsChanOp(chan) && HasVoice(chan))
       sendcmdto_capflag_channel_butserv_butone(&his, CMD_MODE, chan->channel, cptr, 0,
                                        0, CAP_CHGHOST, "%H +ov %C %C", chan->channel, cptr,

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -524,7 +524,7 @@ void sendcmdto_common_channels_butone(struct Client *from, const char *cmd,
  */
 void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *cmd,
 					      const char *tok, struct Client *one,
-					      int require, int forbid, const char *pattern, ...)
+					      capset_t require, capset_t forbid, const char *pattern, ...)
 {
   struct VarData vd;
   struct MsgBuf *mb;
@@ -591,7 +591,8 @@ void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *c
 void sendcmdto_capflag_channel_butserv_butone(struct Client *from, const char *cmd,
 					      const char *tok, struct Channel *to,
 					      struct Client *one, unsigned int skip,
-					      int require, int forbid, const char *pattern, ...)
+					      capset_t require, capset_t forbid,
+					      const char *pattern, ...)
 {
   struct VarData vd;
   struct MsgBuf *mb;
@@ -620,6 +621,40 @@ void sendcmdto_capflag_channel_butserv_butone(struct Client *from, const char *c
   }
 
   msgq_clean(mb);
+}
+
+/* Send JOIN to all local channel users matching or not matching
+ * capability flags.
+ * @param[in] from Client joining the channel.
+ * @param[in] chptr Channel being joined.
+ * @param[in] require Capability mask to send this message for.
+ * @param[in] forbid Capability mask to block this message for.
+ */
+void sendjointo_channel_butserv(struct Client *from, struct Channel *chptr,
+				capset_t require,
+				capset_t forbid)
+{
+  sendcmdto_capflag_channel_butserv_butone(from, CMD_JOIN, chptr, NULL,
+    0, require | CAP_EXTJOIN, forbid, "%H %s :%s", chptr,
+    IsAccount(from) ? cli_account(from) : "*", cli_info(from));
+  sendcmdto_capflag_channel_butserv_butone(from, CMD_JOIN, chptr, NULL,
+    0, require, forbid | CAP_EXTJOIN, "%H", chptr);
+}
+
+/* Send JOIN to a single user.
+ * @param[in] from Client joining the channel.
+ * @param[in] chptr Channel being joined.
+ * @param[in] one Client to send the message to.
+ */
+void sendjointo_one(struct Client *from,
+		    struct Channel *chptr,
+		    struct Client *one)
+{
+  if (CapHas(cli_active(one), CAP_EXTJOIN))
+    sendcmdto_one(one, CMD_JOIN, from, "%H %s :%s", chptr,
+      IsAccount(from) ? cli_account(from) : "*", cli_info(from));
+  else
+    sendcmdto_one(one, CMD_JOIN, from, "%H", chptr);
 }
 
 /** Send a (prefixed) command to all local users on a channel.

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -559,8 +559,8 @@ void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *c
           && -1 < cli_fd(cli_from(member->user))
           && member->user != one
           && cli_sentalong(member->user) != sentalong_marker
-          && CapHas(cli_active(member->user), require)
-          && !CapHas(cli_active(member->user), forbid))
+          && (require == 0 || CapHas(cli_active(member->user), require))
+          && (forbid == 0 || !CapHas(cli_active(member->user), forbid)))
       {
           cli_sentalong(member->user) = sentalong_marker;
           send_buffer(member->user, mb, 0);
@@ -570,8 +570,8 @@ void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *c
 
   if (MyConnect(from)
       && from != one
-      && (require == _CAP_LAST_CAP || CapHas(cli_active(from), require))
-      && (forbid == _CAP_LAST_CAP || !CapHas(cli_active(from), forbid)))
+      && (require == 0 || CapHas(cli_active(from), require))
+      && (forbid == 0 || !CapHas(cli_active(from), forbid)))
     send_buffer(from, mb, 0);
 
   msgq_clean(mb);
@@ -613,8 +613,8 @@ void sendcmdto_capflag_channel_butserv_butone(struct Client *from, const char *c
         || (skip & SKIP_DEAF && IsDeaf(member->user))
         || (skip & SKIP_NONOPS && !IsChanOp(member))
         || (skip & SKIP_NONVOICES && !IsChanOp(member) && !HasVoice(member))
-        || !CapHas(cli_active(member->user), require)
-        || CapHas(cli_active(member->user), forbid))
+        || (require && !CapHas(cli_active(member->user), require))
+        || (forbid && CapHas(cli_active(member->user), forbid)))
         continue;
 
     send_buffer(member->user, mb, 0);
@@ -651,10 +651,10 @@ void sendjointo_one(struct Client *from,
 		    struct Client *one)
 {
   if (CapHas(cli_active(one), CAP_EXTJOIN))
-    sendcmdto_one(one, CMD_JOIN, from, "%H %s :%s", chptr,
+    sendcmdto_one(from, CMD_JOIN, one, "%H %s :%s", chptr,
       IsAccount(from) ? cli_account(from) : "*", cli_info(from));
   else
-    sendcmdto_one(one, CMD_JOIN, from, "%H", chptr);
+    sendcmdto_one(from, CMD_JOIN, one, "%H", chptr);
 }
 
 /** Send a (prefixed) command to all local users on a channel.

--- a/ircd/send.c
+++ b/ircd/send.c
@@ -559,8 +559,8 @@ void sendcmdto_capflag_common_channels_butone(struct Client *from, const char *c
           && -1 < cli_fd(cli_from(member->user))
           && member->user != one
           && cli_sentalong(member->user) != sentalong_marker
-          && (require == _CAP_LAST_CAP || CapHas(cli_active(member->user), require))
-          && (forbid == _CAP_LAST_CAP || !CapHas(cli_active(member->user), forbid)))
+          && CapHas(cli_active(member->user), require)
+          && !CapHas(cli_active(member->user), forbid))
       {
           cli_sentalong(member->user) = sentalong_marker;
           send_buffer(member->user, mb, 0);
@@ -612,8 +612,8 @@ void sendcmdto_capflag_channel_butserv_butone(struct Client *from, const char *c
         || (skip & SKIP_DEAF && IsDeaf(member->user))
         || (skip & SKIP_NONOPS && !IsChanOp(member))
         || (skip & SKIP_NONVOICES && !IsChanOp(member) && !HasVoice(member))
-        || (require < _CAP_LAST_CAP && !CapHas(cli_active(member->user), require))
-        || (forbid < _CAP_LAST_CAP && CapHas(cli_active(member->user), forbid)))
+        || !CapHas(cli_active(member->user), require)
+        || CapHas(cli_active(member->user), forbid))
         continue;
 
     send_buffer(member->user, mb, 0);


### PR DESCRIPTION
* Fix to CAP handler for unregistered connections
* Convert struct CapSet to a bare bitfield
* Consistently honour CAP_EXTJOIN
* Consistently honour CAP_AWAYNOTIFY on join