### PR TITLE
Fix bug that rejects valid usernames with two digit groups

### DIFF
--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -337,7 +337,7 @@ static int auth_set_username(struct AuthRequest *auth)
       goto badid;
     /* If two different groups of digits, one must be either at the
      * start or end. */
-    if (digitgroups == 2 && !(IsDigit(s[0]) || IsDigit(ch)))
+    if (digitgroups == 2 && !(IsDigit(s[0]) || IsDigit(last)))
       goto badid;
     /* Final character must not be punctuation. */
     if (!IsAlnum(last))


### PR DESCRIPTION
The code is supposed to reject usernames that contain two digit groups, unless one of the groups is at the start or end of the username. However, at the end of the loop, 'ch' is the null byte, so usernames that ended with a second digit group were being rejected.

Fix this by checking 'last' instead of 'ch'.