### PR TITLE
Remote +x

### DIFF
--- a/ircd/m_account.c
+++ b/ircd/m_account.c
@@ -87,9 +87,11 @@
 #include "ircd_string.h"
 #include "msg.h"
 #include "numnicks.h"
+#include "s_conf.h"
 #include "s_debug.h"
 #include "s_user.h"
 #include "send.h"
+#include "numeric.h"
 
 /* #include <assert.h> -- Now using assert in ircd_log.h */
 #include <stdlib.h>
@@ -108,6 +110,7 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
 	       char* parv[])
 {
   struct Client *acptr;
+  struct ConfItem *conf;
   uint64_t acc_id = 0, acc_flags = 0;
 
   if (parc < 3)
@@ -116,6 +119,9 @@ int ms_account(struct Client* cptr, struct Client* sptr, int parc,
   if (!IsServer(sptr))
     return protocol_violation(cptr, "ACCOUNT from non-server %s",
 			      cli_name(sptr));
+
+  if (!(conf = find_conf_byhost(cli_confs(cptr), cli_name(sptr), CONF_UWORLD)))
+    return send_reply(sptr, ERR_NOPRIVILEGES, parv[1]); /* Ignore ACCOUNT from non U:lined servers. */
 
   if (!(acptr = findNUser(parv[1])))
     return 0; /* Ignore ACCOUNT for a user that QUIT; probably crossed */

--- a/ircd/m_opmode.c
+++ b/ircd/m_opmode.c
@@ -182,16 +182,22 @@ int ms_opmode(struct Client* cptr, struct Client* sptr, int parc, char* parv[])
     }
 
     conf = find_conf_byhost(cli_confs(cptr), cli_name(sptr), CONF_UWORLD);
-    if (!conf || !(conf->flags & CONF_UWORLD_OPER))
+    if (!conf || ((!strcmp(parv[2], "+o") || !strcmp(parv[2], "-o")) && !(conf->flags & CONF_UWORLD_OPER)))
       return send_reply(sptr, ERR_NOPRIVILEGES, parv[1]);
 
-    /* At the moment, we only support +o and -o.  set_user_mode() does
+    /* At the moment, we only support +o, -o and +x.  set_user_mode() does
      * not support remote mode setting or setting +o.
      */
     if (!strcmp(parv[2], "+o") && !IsOper(dptr))
       make_oper(sptr, dptr);
     else if (!strcmp(parv[2], "-o") && IsOper(dptr))
       de_oper(dptr);
+    else if (!strcmp(parv[2], "+x") && IsAccount(dptr) && !HasHiddenHost(dptr)) {
+      struct Flags old_mode = cli_flags(dptr);
+      SetHiddenHost(dptr);
+      send_umode_out(dptr, dptr, &old_mode, HasPriv(dptr, PRIV_PROPAGATE));
+      hide_hostmask(dptr, FLAG_HIDDENHOST);
+    }
 
     return 0;
   }


### PR DESCRIPTION
* Allow U:lined servers to set umode +x remotely using OPMODE.
* Only permit ACCOUNT messages from U:lined servers.