### PR TITLE
Feature/iauthverify

### DIFF
--- a/include/s_auth.h
+++ b/include/s_auth.h
@@ -39,6 +39,7 @@ extern int auth_set_pong(struct AuthRequest *auth, unsigned int cookie);
 extern int auth_set_user(struct AuthRequest *auth, const char *username, const char *hostname, const char *servername, const char *userinfo);
 extern int auth_set_nick(struct AuthRequest *auth, const char *nickname);
 extern int auth_set_password(struct AuthRequest *auth, const char *password);
+extern int auth_set_account(struct AuthRequest *auth, const char *account_info);
 extern int auth_cap_start(struct AuthRequest *auth);
 extern int auth_cap_done(struct AuthRequest *auth);
 extern int auth_spoof_user(struct AuthRequest *auth, const char *username, const char *hostname, const char *ip);

--- a/ircd/ircd_netconf.c
+++ b/ircd/ircd_netconf.c
@@ -287,7 +287,7 @@ void config_burst(struct Client *cptr)
                   entry->timestamp, entry->key, entry->value);
   }
 
-  Debug((DEBUG_INFO, "Config burst: %d entries sent to %s",
+  Debug((DEBUG_DEBUG, "Config burst: %d entries sent to %s",
          config_count(), cli_name(cptr)));
 }
 

--- a/ircd/m_sasl.c
+++ b/ircd/m_sasl.c
@@ -95,7 +95,6 @@
 
 #include <stdlib.h>
 
-
 /** SASL timeout callback - called when a SASL session times out
  * @param[in] ev Timer event (contains client pointer in timer data)
  */

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -987,8 +987,7 @@ int auth_ping_timeout(struct Client *cptr)
 
   /* Check for iauth timeout. */
   if (FlagHas(&auth->flags, AR_IAUTH_PENDING)) {
-    if (IAuthHas(iauth, IAUTH_REQUIRED)
-        && !FlagHas(&auth->flags, AR_IAUTH_SOFT_DONE)) {
+    if (IAuthHas(iauth, IAUTH_REQUIRED)) {
       sendheader(cptr, REPORT_FAIL_IAUTH);
       return exit_client_msg(cptr, cptr, &me, "Authorization Timeout");
     }

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -375,6 +375,50 @@ badid:
   return exit_client(sptr, sptr, &me, "USER: Bad username");
 }
 
+/** Set account for user associated with \a auth.
+ * @param[in] auth Authorization request for client.
+ */
+int auth_set_account(struct AuthRequest *auth, const char *account_info)
+{
+  assert(auth != NULL);
+
+  struct Client *sptr = auth->client;
+  char *account_copy = NULL, *account = NULL, *id_str = NULL, *flags_str = NULL, *extra = NULL;
+
+  /* Parse account information: username:id:flags */
+  DupString(account_copy, account_info);
+  if (!account_copy)
+    return 1;
+
+  account = strtok(account_copy, ":");
+  id_str = strtok(NULL, ":");
+  flags_str = strtok(NULL, " ");
+  extra = strtok(NULL, "");
+
+  /* Copy account name to User structure */
+  ircd_strncpy(cli_user(sptr)->account, account, ACCOUNTLEN);
+
+  /* Parse account ID if provided */
+  if (id_str) {
+    cli_user(sptr)->acc_id = strtoul(id_str, NULL, 10);
+  }
+
+  if (flags_str) {
+    cli_user(sptr)->acc_flags = strtoul(flags_str, NULL, 10);
+  }
+
+  SetAccount(sptr);
+
+  /* Check for +x flag (host hiding) */
+  if (extra && strstr(extra, "+x") && feature_bool(FEAT_HOST_HIDING)) {
+    SetHiddenHost(sptr);
+  }
+
+  sendto_iauth(sptr, "A %s", cli_user(sptr)->account);
+  MyFree(account_copy);
+  return 0;
+}
+
 /** Notifies IAuth of a status change for the client.
  *
  * @param[in] auth Authorization request that was updated.
@@ -411,7 +455,8 @@ static void iauth_notify(struct AuthRequest *auth, enum AuthRequestFlag flag)
     break;
 
   case AR_IAUTH_PENDING:
-    sendto_iauth(sptr, "T");
+    if (!FlagHas(&auth->flags, AR_CAP_PENDING))
+      sendto_iauth(sptr, "T");
     break;
 
   default:
@@ -1321,6 +1366,7 @@ int auth_cap_start(struct AuthRequest *auth)
 {
   assert(auth != NULL);
   FlagSet(&auth->flags, AR_CAP_PENDING);
+  sendto_iauth(auth->client, "c");
   return 0;
 }
 
@@ -1332,6 +1378,7 @@ int auth_cap_start(struct AuthRequest *auth)
 int auth_cap_done(struct AuthRequest *auth)
 {
   assert(auth != NULL);
+  sendto_iauth(auth->client, "e");
   return check_auth_finished(auth, AR_CAP_PENDING);
 }
 

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -380,10 +380,14 @@ badid:
  */
 int auth_set_account(struct AuthRequest *auth, const char *account_info)
 {
+  struct Client *sptr;
+  char *account_copy = NULL, *account = NULL, *id_str = NULL, *flags_str = NULL, *extra = NULL;
+
   assert(auth != NULL);
 
-  struct Client *sptr = auth->client;
-  char *account_copy = NULL, *account = NULL, *id_str = NULL, *flags_str = NULL, *extra = NULL;
+  sptr = auth->client;
+  if (!cli_user(sptr) || EmptyString(account_info))
+    return 1;
 
   /* Parse account information: username:id:flags */
   DupString(account_copy, account_info);
@@ -394,6 +398,12 @@ int auth_set_account(struct AuthRequest *auth, const char *account_info)
   id_str = strtok(NULL, ":");
   flags_str = strtok(NULL, " ");
   extra = strtok(NULL, "");
+
+  /* A malformed reply may contain no account name at all. */
+  if (EmptyString(account)) {
+    MyFree(account_copy);
+    return 1;
+  }
 
   /* Copy account name to User structure */
   ircd_strncpy(cli_user(sptr)->account, account, ACCOUNTLEN);

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -1389,7 +1389,8 @@ int auth_cap_start(struct AuthRequest *auth)
 int auth_cap_done(struct AuthRequest *auth)
 {
   assert(auth != NULL);
-  sendto_iauth(auth->client, "e");
+  if (FlagHas(&auth->flags, AR_CAP_PENDING))
+    sendto_iauth(auth->client, "e");
   return check_auth_finished(auth, AR_CAP_PENDING);
 }
 

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -1364,8 +1364,10 @@ void auth_send_xreply(struct Client *sptr, const char *routing,
 int auth_cap_start(struct AuthRequest *auth)
 {
   assert(auth != NULL);
-  FlagSet(&auth->flags, AR_CAP_PENDING);
-  sendto_iauth(auth->client, "c");
+  if (!FlagHas(&auth->flags, AR_CAP_PENDING)) {
+    FlagSet(&auth->flags, AR_CAP_PENDING);
+    sendto_iauth(auth->client, "c");
+  }
   return 0;
 }
 

--- a/ircd/sasl.c
+++ b/ircd/sasl.c
@@ -35,6 +35,7 @@
 #include "msg.h"
 #include "capab.h"
 #include "numnicks.h"
+#include "s_auth.h"
 #include "s_debug.h"
 #include "s_bsd.h"
 #include "numeric.h"
@@ -253,37 +254,7 @@ void sasl_send_xreply(struct Client* sptr, const char* routing, const char* repl
      * If this is a SASL authentication after registration, the username will be set by the service using AC.
      */
     if (!IsUser(cli)) {
-      /* Parse account information: username:id:flags */
-      DupString(account_copy, account_info);
-      if (!account_copy)
-        return;
-      
-      username = strtok(account_copy, ":");
-      id_str = strtok(NULL, ":");
-      flags_str = strtok(NULL, " ");
-      extra = strtok(NULL, "");
-         
-      /* Copy account name to User structure */
-      ircd_strncpy(cli_user(cli)->account, username, ACCOUNTLEN);
-      
-      /* Parse account ID if provided */
-      if (id_str) {
-        cli_user(cli)->acc_id = strtoul(id_str, NULL, 10);
-      }
-      
-      /* Parse account flags if provided */
-      if (flags_str) {
-        cli_user(cli)->acc_flags = strtoul(flags_str, NULL, 10);
-      }
-      
-      SetAccount(cli);
-      
-      /* Check for +x flag (host hiding) */
-      if (extra && strstr(extra, "+x") && feature_bool(FEAT_HOST_HIDING)) {
-        SetHiddenHost(cli);
-      }
-
-      MyFree(account_copy);
+      auth_set_account(cli_auth(cli), account_info);
 
     /**
      * For already registered users, we send RPL_LOGGEDIN. For non-registered users,

--- a/ircd/sasl.c
+++ b/ircd/sasl.c
@@ -246,7 +246,8 @@ void sasl_send_xreply(struct Client* sptr, const char* routing, const char* repl
   if (reply[0] == 'O' && reply[1] == 'K'
                && (reply[2] == '\0' || reply[2] == ' ')) {
     
-    const char *account_info = reply + 3; /* Skip "OK " */
+    /* Skip "OK "; a bare "OK" reply carries no account information. */
+    const char *account_info = (reply[2] == ' ') ? reply + 3 : "";
     char *account_copy, *username, *id_str, *flags_str, *extra;
 
     /**

--- a/ircd/sasl.c
+++ b/ircd/sasl.c
@@ -248,7 +248,6 @@ void sasl_send_xreply(struct Client* sptr, const char* routing, const char* repl
     
     /* Skip "OK "; a bare "OK" reply carries no account information. */
     const char *account_info = (reply[2] == ' ') ? reply + 3 : "";
-    char *account_copy, *username, *id_str, *flags_str, *extra;
 
     /**
      * We only parse this information if the user is not yet registered (i.e. SASL authentication during auth).

--- a/tests/pr_iauthverify/iauth_stub.py
+++ b/tests/pr_iauthverify/iauth_stub.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""IAuth stub for testing the ircd->iauth message stream.
+
+Logs every line received from the ircd to the file given as argv[1]
+and approves every client as soon as its nickname is announced.
+"""
+
+import sys
+
+
+def main():
+    logf = open(sys.argv[1], "a", buffering=1)
+
+    def out(line):
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    # R: iauth is required; U: enable Undernet extensions (U/u/n/H/T).
+    out("O RU")
+
+    clients = {}
+    for line in sys.stdin:
+        line = line.rstrip("\r\n")
+        logf.write(line + "\n")
+        parts = line.split(" ")
+        if len(parts) < 2:
+            continue
+        cid, cmd = parts[0], parts[1]
+        if cmd == "C" and len(parts) >= 4:
+            # "<id> C <ip> <port> ..." -- new client
+            clients[cid] = (parts[2], parts[3])
+        elif cmd == "n" and cid in clients:
+            # Nickname announced: approve the client.
+            ip, port = clients[cid]
+            out(f"D {cid} {ip} {port}")
+        elif cmd == "D":
+            clients.pop(cid, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pr_iauthverify/test_iauth_cap_messages.py
+++ b/tests/pr_iauthverify/test_iauth_cap_messages.py
@@ -1,0 +1,195 @@
+"""TDD tests for the iauthverify branch: CAP start/end notifications to iauth.
+
+The branch introduces two new ircd->iauth messages: "c" when a client
+enters capability negotiation and "e" when it finishes. auth_cap_start()
+only sends "c" the first time (guarded by AR_CAP_PENDING), but
+auth_cap_done() sends "e" unconditionally: a client that sends CAP END
+without ever starting CAP produces a stray "e", and repeated CAP END
+produces duplicate "e" messages. An iauth instance tracking CAP state
+per client would get confused by both.
+
+These tests run the locally built ircd with an iauth stub that logs the
+raw message stream, drive clients through CAP sequences, and assert on
+the logged "c"/"e" messages. They need ircd/ircd compiled for this host
+(run `make` first); they skip if it is missing.
+"""
+
+import asyncio
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IRCD_BIN = REPO_ROOT / "ircd" / "ircd"
+STUB = Path(__file__).resolve().parent / "iauth_stub.py"
+
+pytestmark = pytest.mark.skipif(
+    not IRCD_BIN.exists(), reason="local ircd binary not built"
+)
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _spath():
+    """Read the compiled-in SPATH from config.h (ircd checks it on boot)."""
+    for line in (REPO_ROOT / "config.h").read_text().splitlines():
+        if line.startswith("#define SPATH "):
+            return Path(line.split('"')[1])
+    return None
+
+
+@pytest.fixture
+def ensure_spath():
+    """ircd refuses to start unless SPATH exists; symlink it if missing."""
+    spath = _spath()
+    created = False
+    if spath and not spath.exists() and spath.parent.is_dir():
+        spath.symlink_to(IRCD_BIN)
+        created = True
+    yield
+    if created:
+        spath.unlink(missing_ok=True)
+
+
+CONF_TEMPLATE = """\
+General {{
+        name = "iauthcap.example.net";
+        vhost = "127.0.0.1";
+        description = "iauth cap test server";
+        numeric = 99;
+}};
+Admin {{
+        Location = "test";
+        Location = "test";
+        Contact = "test@example.net";
+}};
+Class {{
+        name = "Local";
+        pingfreq = 90 seconds;
+        sendq = 160000;
+        maxlinks = 100;
+}};
+Client {{ ip = "127.*"; class = "Local"; }};
+Port {{ port = {port}; }};
+IAuth {{ program = "{python}" "{stub}" "{log}"; }};
+"""
+
+
+@pytest.fixture
+def local_ircd(tmp_path, ensure_spath):
+    """Spawn a local ircd with the logging iauth stub attached."""
+    port = _free_port()
+    log = tmp_path / "iauth.log"
+    log.touch()
+    conf = tmp_path / "ircd.conf"
+    conf.write_text(
+        CONF_TEMPLATE.format(
+            port=port,
+            python=sys.executable,
+            stub=STUB,
+            log=log,
+        )
+    )
+    proc = subprocess.Popen(
+        [str(IRCD_BIN), "-n", "-f", str(conf), "-d", str(tmp_path)],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError("ircd exited during startup")
+            try:
+                with socket.create_connection(("127.0.0.1", port), 0.2):
+                    break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise RuntimeError("ircd did not start listening")
+        yield {"port": port, "log": log}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+async def _run_client(port, pre_registration_lines, nick):
+    """Connect, send the given lines, register, and wait for 001."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+    async def send(line):
+        writer.write((line + "\r\n").encode())
+        await writer.drain()
+
+    for line in pre_registration_lines:
+        await send(line)
+    await send(f"NICK {nick}")
+    await send(f"USER testuser 0 * :Test User")
+
+    deadline = asyncio.get_event_loop().time() + 15
+    try:
+        while True:
+            remaining = deadline - asyncio.get_event_loop().time()
+            raw = await asyncio.wait_for(reader.readline(), timeout=remaining)
+            if not raw:
+                raise ConnectionError("server closed connection")
+            line = raw.decode(errors="replace").strip()
+            if line.startswith("PING"):
+                await send("PONG " + line.split(" ", 1)[1])
+            parts = line.split()
+            if len(parts) > 1 and parts[1] == "001":
+                return
+    finally:
+        writer.write(b"QUIT :done\r\n")
+        try:
+            await writer.drain()
+        except OSError:
+            pass
+        writer.close()
+
+
+def _cap_messages(log_path):
+    """Return the list of 'c'/'e' iauth messages, e.g. ['c', 'e']."""
+    msgs = []
+    for line in log_path.read_text().splitlines():
+        parts = line.split(" ")
+        if len(parts) >= 2 and parts[1] in ("c", "e"):
+            msgs.append(parts[1])
+    return msgs
+
+
+async def test_cap_end_without_cap_start_sends_no_e(local_ircd):
+    """A bare CAP END (no CAP LS/REQ first) must not send "e" to iauth.
+
+    The client never entered capability negotiation, so iauth never got
+    a "c" for it; sending "e" anyway confuses iauth's session tracking.
+    """
+    await _run_client(local_ircd["port"], ["CAP END"], "iavcap1")
+    await asyncio.sleep(0.5)
+    assert _cap_messages(local_ircd["log"]) == []
+
+
+async def test_repeated_cap_end_sends_single_e(local_ircd):
+    """CAP END sent twice must produce exactly one "c" and one "e"."""
+    await _run_client(
+        local_ircd["port"],
+        ["CAP LS 302", "CAP END", "CAP END"],
+        "iavcap2",
+    )
+    await asyncio.sleep(0.5)
+    assert _cap_messages(local_ircd["log"]) == ["c", "e"]

--- a/tests/pr_iauthverify/test_sasl_account.py
+++ b/tests/pr_iauthverify/test_sasl_account.py
@@ -1,0 +1,135 @@
+"""TDD tests for the iauthverify branch: auth_set_account() hardening.
+
+The branch moves SASL "OK <account>" reply parsing from sasl.c into
+auth_set_account() in s_auth.c. The parsing uses strtok() and copies the
+result with ircd_strncpy() without checking for NULL: a services server
+that replies "OK" or "OK " (no account name, or a malformed one like
+"OK ::::") makes strtok() return NULL and the ircd dereferences it,
+crashing the whole server.
+
+These tests link a fake P10 services server to the hub, enable SASL via
+netconf, run a client through SASL during registration, and have the
+services server send back malformed OK replies. The server must survive
+and the client must still be able to register.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from irc_client import IRCClient
+from p10_server import P10Server
+
+
+pytestmark = pytest.mark.single_server
+
+
+@pytest.fixture
+async def services(ircd_hub):
+    """Connect a fake P10 services server to the hub and enable SASL."""
+    srv = P10Server(
+        name="services.test.net",
+        numeric=4,
+        password="testpass",
+    )
+    await srv.connect(ircd_hub["host"], ircd_hub["server_port"])
+    await srv.handshake()
+    # Enable SASL through netconf, pointing at ourselves.
+    await srv.send_config("sasl.server", "services.test.net")
+    await srv.send_config("sasl.mechanisms", "PLAIN")
+    await asyncio.sleep(0.5)
+    yield srv
+    await srv.disconnect()
+
+
+async def _start_sasl(client, services):
+    """Negotiate the sasl cap and send AUTHENTICATE PLAIN.
+
+    Returns (hub_numeric, routing) parsed from the XQUERY the hub sends
+    to the services server, so the test can send a matching XREPLY.
+    """
+    await client.send("CAP LS 302")
+    msg = await client.wait_for("CAP", timeout=5.0)
+    assert "sasl" in msg.params[-1], "hub does not advertise sasl"
+
+    await client.send("CAP REQ :sasl")
+    msg = await client.wait_for("CAP", timeout=5.0)
+    assert msg.params[1] == "ACK", f"expected CAP ACK, got {msg.params}"
+
+    await client.send("AUTHENTICATE PLAIN")
+
+    # Hub relays the request: "<hubnum> XQ <servicesnum> sasl:<cookie> :SASL ..."
+    line = await services.wait_for_token("XQ", timeout=5.0)
+    parts = line.split()
+    hub_num = parts[0]
+    routing = parts[3]
+    assert routing.startswith("sasl:")
+    return hub_num, routing
+
+
+async def _finish_registration(client, nick):
+    """Complete registration after SASL and wait for the 001 welcome."""
+    await client.send(f"NICK {nick}")
+    await client.send(f"USER testuser 0 * :Test User")
+    await client.send("CAP END")
+    await client.wait_for("001", timeout=10.0)
+
+
+async def test_sasl_ok_with_valid_account(ircd_hub, services):
+    """Positive control: OK with a full account payload logs the client in."""
+    client = IRCClient()
+    await client.connect(ircd_hub["host"], ircd_hub["port"])
+    try:
+        hub_num, routing = await _start_sasl(client, services)
+        await services.send_xreply(hub_num, routing, "OK goodacct:42:0 +x")
+
+        msg = await client.wait_for("903", timeout=5.0)
+        assert msg is not None
+
+        await _finish_registration(client, "iavok1")
+
+        # The account must be attached: WHOIS shows 330 (RPL_WHOISACCOUNT).
+        await client.send("WHOIS iavok1")
+        found_account = None
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            msg = await client.recv(timeout=5.0)
+            if msg.command == "330":
+                found_account = msg.params[2]
+            if msg.command == "318":  # end of WHOIS
+                break
+        assert found_account == "goodacct"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.parametrize("bad_reply", ["OK", "OK ", "OK ::::"])
+async def test_sasl_ok_without_account_must_not_crash(
+    ircd_hub, services, bad_reply
+):
+    """An OK reply with a missing or malformed account must not kill the ircd.
+
+    On the unfixed branch, auth_set_account() passes strtok()'s NULL
+    result to ircd_strncpy() and the server segfaults.
+    """
+    client = IRCClient()
+    await client.connect(ircd_hub["host"], ircd_hub["port"])
+    try:
+        hub_num, routing = await _start_sasl(client, services)
+        await services.send_xreply(hub_num, routing, bad_reply)
+
+        # Whatever the server decides about the reply, it must stay up:
+        # the client must still be able to finish registering...
+        await _finish_registration(client, "iavbad1")
+    finally:
+        await client.disconnect()
+
+    # ...and brand-new connections must still be accepted.
+    probe = IRCClient()
+    await probe.connect(ircd_hub["host"], ircd_hub["port"])
+    try:
+        await probe.register("iavprobe", "testuser", "Test User")
+    finally:
+        await probe.send("QUIT :done")
+        await probe.disconnect()


### PR DESCRIPTION
* Pass account to IAuth if SASL authentication occurs during registration
* Ensure that IAuth session lasts until cap negotiation has ended, because SASL Authentication during registration should occur prior to CAP END.
* If the IAUTH_REQUIRED policy is set, we will the client on timeout even if the client is soft_done. 