### PR TITLE
Add support for usermode +c

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -93,7 +93,7 @@ typedef unsigned long flagpage_t;
 #define FlagClr(set,flag) ((set)->bits[FLAGSET_INDEX(flag)] &= ~FLAGSET_MASK(flag))
 
 /** String containing valid user modes, in no particular order. */
-#define infousermodes "diOoswkgxz"
+#define infousermodes "diOoswkgxcz"
 
 /** Operator privileges. */
 enum Priv
@@ -175,6 +175,7 @@ enum Flag
     FLAG_CAP302,                    /**< client supports IRCv3.2 */
     FLAG_TLS,                       /**< user is using TLS */
     FLAG_SPAMHOLD,                  /**< user is the sender or recipient of a message on hold */
+    FLAG_COMMONCHANS,               /**< only accepts messages from users in common channels */
     FLAG_LAST_FLAG,                 /**< number of flags */
     FLAG_LOCAL_UMODES = FLAG_LOCOP, /**< First local mode flag */
     FLAG_GLOBAL_UMODES = FLAG_OPER  /**< First global mode flag */
@@ -629,6 +630,8 @@ struct Client {
 #define IsNegotiatingTLS(x)     HasFlag(x, FLAG_NEGOTIATING_TLS)
 /** Return non-zero if the client is the sender or recipient of a message on hold (spamfilter) */
 #define IsSpamHold(x)           HasFlag(x, FLAG_SPAMHOLD)
+/** Return non-zero if the client has mode +c (only messages from common channels). */
+#define IsCommonChans(x)        HasFlag(x, FLAG_COMMONCHANS)
 
 /** Return non-zero if the client has operator or server privileges. */
 #define IsPrivileged(x)         (IsAnOper(x) || IsServer(x))
@@ -681,6 +684,8 @@ struct Client {
 #define SetNegotiatingTLS(x)    SetFlag(x, FLAG_NEGOTIATING_TLS)
 /** Mark a client as being the sender or recipient of a message on hold (spamfilter). */
 #define SetSpamHold(x)          SetFlag(x, FLAG_SPAMHOLD)
+/** Mark a client as having mode +c (only messages from those in common channels). */
+#define SetCommonChans(x)       SetFlag(x, FLAG_COMMONCHANS)
 
 /** Return non-zero if \a sptr sees \a acptr as an operator. */
 #define SeeOper(sptr,acptr) (IsAnOper(acptr) && (HasPriv(acptr, PRIV_DISPLAY) \
@@ -720,6 +725,8 @@ struct Client {
 #define ClearNegotiatingTLS(x)  ClrFlag(x, FLAG_NEGOTIATING_TLS)
 /** Clear the client's spam hold flag. */
 #define ClearSpamHold(x)        ClrFlag(x, FLAG_SPAMHOLD)
+/** Remove mode +c (only accepts messages from common channels) from the client. */
+#define ClearCommonChans(x)     ClrFlag(x, FLAG_COMMONCHANS)
 
 /* free flags */
 #define FREEFLAG_SOCKET	0x0001	/**< socket needs to be freed */

--- a/ircd/ircd_relay.c
+++ b/ircd/ircd_relay.c
@@ -417,6 +417,28 @@ void relay_directed_notice(struct Client* sptr, char* name, char* server, const 
   }
 }
 
+/** Check if two users share a common channel.
+ * @param[in] sptr Source client.
+ * @param[in] acptr Target client.
+ * @return Non-zero if users share a channel, zero otherwise.
+ */
+static int has_common_channel(struct Client *sptr, struct Client *acptr)
+{
+  struct Membership *schan, *achan;
+
+  for (schan = cli_user(sptr)->channel; schan; schan = schan->next_channel) {
+    if (IsZombie(schan) || IsDelayedJoin(schan))
+      continue;
+    for (achan = cli_user(acptr)->channel; achan; achan = achan->next_channel) {
+      if (IsZombie(achan) || IsDelayedJoin(achan))
+        continue;
+      if (schan->channel == achan->channel)
+        return 1;  /* Found common channel */
+    }
+  }
+  return 0;  /* No common channels */
+}
+
 /** Relay a private message from a local user.
  * Returns an error if the user does not exist or sending to him would
  * exceed the source's free targets.  Sends an AWAY status message if
@@ -445,6 +467,12 @@ void relay_private_message(struct Client* sptr, const char* name, const char* te
 
   if (sline_check_privmsg(sptr, acptr, text, MSG_PRIVATE)) {
     return;
+  }
+
+  /* Check +c mode: block private messages from users not in common channels */
+  if (IsCommonChans(acptr) && !IsChannelService(sptr) && !IsOper(sptr)) {
+    if (!has_common_channel(sptr, acptr))
+      return;
   }
 
   /*
@@ -488,6 +516,12 @@ void relay_private_notice(struct Client* sptr, const char* name, const char* tex
 
   if (sline_check_privmsg(sptr, acptr, text, MSG_NOTICE)) {
     return;
+  }
+  
+  /* Check +c mode: block notices from users not in common channels */
+  if (IsCommonChans(acptr) && !IsChannelService(sptr) && !IsOper(sptr)) {
+    if (!has_common_channel(sptr, acptr))
+      return;
   }
 
   /*

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -500,7 +500,8 @@ static const struct UserMode {
   { FLAG_DEBUG,       'g' },
   { FLAG_ACCOUNT,     'r' },
   { FLAG_HIDDENHOST,  'x' },
-  { FLAG_TLS,         'z' }
+  { FLAG_TLS,         'z' },
+  { FLAG_COMMONCHANS, 'c' }
 };
 
 /** Length of #userModeList. */
@@ -1095,12 +1096,19 @@ int set_user_mode(struct Client *cptr, struct Client *sptr, int parc,
         }
         /* There is no -z */
         break;
+      case 'c':
+        if (what == MODE_ADD)
+          SetCommonChans(sptr);
+        else
+          ClearCommonChans(sptr);
+        break;
       default:
         send_reply(sptr, ERR_UMODEUNKNOWNFLAG, *m);
         break;
       }
     }
   }
+  
   /*
    * Evaluate rules for new user mode
    * Stop users making themselves operators too easily:


### PR DESCRIPTION
- Drops incoming messages (privmsg, notice, CTCP) from clients not in a common channel
- Services and opers are exempt