### PR TITLE
Apply input throttling to WebSocket clients

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -138,6 +138,14 @@ Admin {
 # are fewer than maxlinks clients in the class, up to a limit of about
 # 4,000,000,000.
 #
+# maxflood sets the client flood buffer (recvQ) limit in bytes for the
+# class; if unset it defaults to the CLIENT_FLOOD feature value.  NOTE:
+# setting maxflood higher than CLIENT_FLOOD also exempts clients in the
+# class from input throttling (the per-command penalty delay), letting
+# them send bursts without being slowed down.  The flood buffer limit
+# itself still applies -- a client exceeding maxflood is disconnected
+# for Excess Flood as usual.
+#
 # <connect freq> applies only to servers, and specifies the frequency
 # that the server tries to autoconnect. setting this to 0 will cause
 # the server to attempt to connect repeatedly with no delay until the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - "4400:4400"
       - "7000:7000"
       - "7001:7001"
+      - "7002:7002"
     networks:
       ircu-test-net:
         ipv4_address: 10.55.0.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     ports:
       - "6668:6668"
       - "4401:4401"
+      - "6690:6690"
     networks:
       ircu-test-net:
         ipv4_address: 10.55.0.11

--- a/include/client.h
+++ b/include/client.h
@@ -162,6 +162,7 @@ enum Flag
     FLAG_IPCHECK,                   /**< Added or updated IPregistry data */
     FLAG_IAUTH_STATS,               /**< Wanted IAuth statistics */
     FLAG_NEGOTIATING_TLS,           /**< TLS negotation ongoing */
+    FLAG_EXEMPT_THROTTLE,           /**< exempt from input throttling (raised-maxflood class) */
 
     FLAG_LOCOP,                     /**< Local operator -- SRB */
     FLAG_SERVNOTICE,                /**< server notices such as kill */
@@ -659,6 +660,8 @@ struct Client {
 #define IsSpamHold(x)           HasFlag(x, FLAG_SPAMHOLD)
 /** Return non-zero if the client has mode +c (only messages from common channels). */
 #define IsCommonChans(x)        HasFlag(x, FLAG_COMMONCHANS)
+/** Return non-zero if the client is exempt from input throttling. */
+#define IsExemptThrottle(x)     HasFlag(x, FLAG_EXEMPT_THROTTLE)
 
 /** Return non-zero if the client has completed the handshake for a WebSocket connection. */
 #define IsWebsocket(x)           (cli_ws_mode(x) != WS_NONE)
@@ -717,6 +720,8 @@ struct Client {
 #define SetSpamHold(x)          SetFlag(x, FLAG_SPAMHOLD)
 /** Mark a client as having mode +c (only messages from those in common channels). */
 #define SetCommonChans(x)       SetFlag(x, FLAG_COMMONCHANS)
+/** Mark a client as being exempt from input throttling. */
+#define SetExemptThrottle(x)    SetFlag(x, FLAG_EXEMPT_THROTTLE)
 
 /** Return non-zero if \a sptr sees \a acptr as an operator. */
 #define SeeOper(sptr,acptr) (IsAnOper(acptr) && (HasPriv(acptr, PRIV_DISPLAY) \
@@ -760,6 +765,8 @@ struct Client {
 #define ClearSpamHold(x)        ClrFlag(x, FLAG_SPAMHOLD)
 /** Remove mode +c (only accepts messages from common channels) from the client. */
 #define ClearCommonChans(x)     ClrFlag(x, FLAG_COMMONCHANS)
+/** Mark a client as no longer exempt from input throttling. */
+#define ClearExemptThrottle(x)  ClrFlag(x, FLAG_EXEMPT_THROTTLE)
 
 /* free flags */
 #define FREEFLAG_SOCKET	0x0001	/**< socket needs to be freed */

--- a/include/dbuf.h
+++ b/include/dbuf.h
@@ -56,7 +56,6 @@ extern int dbuf_put(struct DBuf *dyn, const char *buf, unsigned int length);
 extern const char *dbuf_map(const struct DBuf *dyn, unsigned int *length);
 extern unsigned int dbuf_get(struct DBuf *dyn, char *buf, unsigned int length);
 extern unsigned int dbuf_getmsg(struct DBuf *dyn, char *buf, unsigned int length);
-extern unsigned int dbuf_getframe(struct DBuf *dyn, char *buf, unsigned int length);
 extern void dbuf_count_memory(size_t *allocated, size_t *used);
 
 

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -29,10 +29,9 @@
 int websocket_handshake_handler(struct Client *cptr);
 /** Send an HTTP 400 response for a failed handshake (before closing). */
 int websocket_send_http_error(struct Client *cptr);
-/** Parse one WebSocket frame. On a data/continuation frame, *msg_ready is set
- * to 1 when the frame carries FIN (logical message complete), else 0. */
-int websocket_parse_frame(struct Client *cptr, const char *buf, size_t buflen,
-                          int *msg_ready);
+/** Parse one WebSocket frame; decoded payload is pushed into recvQ, with a
+ * newline appended on the final fragment (FIN) to terminate the IRC line. */
+int websocket_parse_frame(struct Client *cptr, const char *buf, size_t buflen);
 struct MsgBuf *websocket_frame_msgbuf(struct Client *cptr, const char *line, size_t linelen);
 /** RFC 6455 Ping (not IRC PING); 0 on success, -1 on write failure. */
 int websocket_send_keepalive_ping(struct Client *cptr);

--- a/ircd/dbuf.c
+++ b/ircd/dbuf.c
@@ -330,21 +330,6 @@ static unsigned int dbuf_flush(struct DBuf *dyn)
   return dyn->length;
 }
 
-/** Extract the entire buffer as a single frame (for WebSocket).
- * Copies up to 'length' bytes from the buffer, regardless of EOL.
- * Deletes the bytes from the buffer after copying.
- * Returns the number of bytes copied.
- */
-unsigned int dbuf_getframe(struct DBuf *dyn, char *buf, unsigned int length)
-{
-  unsigned int to_copy = (length < dyn->length) ? length : dyn->length;
-  if (to_copy == 0)
-    return 0;
-  unsigned int copied = dbuf_get(dyn, buf, to_copy);
-  buf[copied] = '\0';
-  return copied;
-}
-
 /** Copy a single line from a data buffer.
  * If the output buffer cannot hold the whole line, or if there is no
  * EOL in the buffer, return 0.

--- a/ircd/s_bsd.c
+++ b/ircd/s_bsd.c
@@ -660,6 +660,21 @@ static int read_packet(struct Client *cptr, int socket_ready)
 
   int is_ws_handshake = (IsWebsocketPort(cptr) && !IsWebsocket(cptr));
   unsigned int flood_limit = is_ws_handshake ? WEBSOCKET_MAX_HEADER : GetMaxFlood(cptr);
+
+  /* A connection class whose maxflood exceeds the CLIENT_FLOOD default marks
+   * its clients exempt from input throttling. Evaluated here in the shared
+   * prologue so the flag is consistent for both the line-based and WebSocket
+   * readers, and re-checked each read so it tracks class changes. Note the
+   * Excess Flood ceiling below still applies -- this exempts from throttling,
+   * not from the recvQ limit.
+   */
+  if (!is_ws_handshake) {
+    if (flood_limit > feature_int(FEAT_CLIENT_FLOOD))
+      SetExemptThrottle(cptr);
+    else
+      ClearExemptThrottle(cptr);
+  }
+
   if (socket_ready &&
       !(IsUser(cptr) &&
 	DBufLength(&(cli_recvQ(cptr))) > flood_limit)) {
@@ -788,7 +803,15 @@ static int read_packet(struct Client *cptr, int socket_ready)
               return exit_client(cptr, cptr, &me, "Excess Flood");
 
             /* Only drain once a full logical message has arrived (FIN); a
-             * fragmented message keeps accumulating in recvQ until then. */
+             * fragmented message keeps accumulating in recvQ until then.
+             *
+             * NOTE: unlike the line-based reader below, this path does not
+             * enforce the cli_since penalty gate, so WebSocket clients are
+             * not currently throttled (the Excess Flood ceiling above still
+             * bounds them). FLAG_EXEMPT_THROTTLE is maintained for them in
+             * the shared prologue so it is correct once throttle enforcement
+             * is added to this reader in a follow-up change.
+             */
             if (msg_ready) {
               dolen = dbuf_getframe(&(cli_recvQ(cptr)), cli_buffer(cptr), BUFSIZE);
               if (dolen == 0) {
@@ -852,8 +875,8 @@ static int read_packet(struct Client *cptr, int socket_ready)
     if (DBufLength(&(cli_recvQ(cptr))) > GetMaxFlood(cptr))
       return exit_client(cptr, cptr, &me, "Excess Flood");
 
-    while (DBufLength(&(cli_recvQ(cptr))) && !NoNewLine(cptr) && 
-           (IsTrusted(cptr) || cli_since(cptr) - CurrentTime < 10))
+    while (DBufLength(&(cli_recvQ(cptr))) && !NoNewLine(cptr) &&
+           (IsTrusted(cptr) || IsExemptThrottle(cptr) || cli_since(cptr) - CurrentTime < 10))
     {
       dolen = dbuf_getmsg(&(cli_recvQ(cptr)), cli_buffer(cptr), BUFSIZE);
       /*
@@ -898,14 +921,16 @@ static int read_packet(struct Client *cptr, int socket_ready)
       }
     }
 
-    /* If there's still data to process, wait 2 seconds first */
+    /* If there's still data to process, wait 2 seconds first,
+     * unless the client is exempt from throttling.
+     */
     if (DBufLength(&(cli_recvQ(cptr))) && !NoNewLine(cptr) &&
-	!t_onqueue(&(cli_proc(cptr))))
+        !IsExemptThrottle(cptr) && !t_onqueue(&(cli_proc(cptr))))
     {
       Debug((DEBUG_LIST, "Adding client process timer for %C", cptr));
       cli_freeflag(cptr) |= FREEFLAG_TIMER;
       timer_add(&(cli_proc(cptr)), client_timer_callback, cli_connect(cptr),
-		TT_RELATIVE, 2);
+                TT_RELATIVE, 2);
     }
   }
   return 1;

--- a/ircd/s_bsd.c
+++ b/ircd/s_bsd.c
@@ -784,10 +784,8 @@ static int read_packet(struct Client *cptr, int socket_ready)
         }
 
         while (offset < con->con_ws_handshake_len) {
-          int msg_ready = 0;
           int ret = websocket_parse_frame(cptr, con->con_ws_handshake + offset,
-                                          con->con_ws_handshake_len - offset,
-                                          &msg_ready);
+                                          con->con_ws_handshake_len - offset);
           if (ret > 0) {
             size_t avail = con->con_ws_handshake_len - offset;
             if ((size_t)ret <= avail) {
@@ -798,33 +796,10 @@ static int read_packet(struct Client *cptr, int socket_ready)
               offset = con->con_ws_handshake_len;
             }
 
-            /* Bound recvQ growth even while fragments accumulate unfinished. */
+            /* Bound recvQ growth even while fragments accumulate unfinished.
+             * Completed lines are drained (and throttled) after the read. */
             if (DBufLength(&(cli_recvQ(cptr))) > GetMaxFlood(cptr))
               return exit_client(cptr, cptr, &me, "Excess Flood");
-
-            /* Only drain once a full logical message has arrived (FIN); a
-             * fragmented message keeps accumulating in recvQ until then.
-             *
-             * NOTE: unlike the line-based reader below, this path does not
-             * enforce the cli_since penalty gate, so WebSocket clients are
-             * not currently throttled (the Excess Flood ceiling above still
-             * bounds them). FLAG_EXEMPT_THROTTLE is maintained for them in
-             * the shared prologue so it is correct once throttle enforcement
-             * is added to this reader in a follow-up change.
-             */
-            if (msg_ready) {
-              dolen = dbuf_getframe(&(cli_recvQ(cptr)), cli_buffer(cptr), BUFSIZE);
-              if (dolen == 0) {
-                if (DBufLength(&(cli_recvQ(cptr))) > 510) {
-                  /* More than 510 bytes in the line - drop the input and yell
-                  * at the client.
-                  */
-                  DBufClear(&(cli_recvQ(cptr)));
-                  send_reply(cptr, ERR_INPUTTOOLONG);
-                }
-              } else if (client_dopacket(cptr, dolen) == CPTR_KILLED)
-                return CPTR_KILLED;
-            }
 
             if (con->con_ws_skip > 0)
               break; /* remainder of oversized frame drains on later reads */
@@ -860,15 +835,13 @@ static int read_packet(struct Client *cptr, int socket_ready)
         if (take == 0 && offset == 0 && con->con_ws_skip == 0)
           return exit_client(cptr, cptr, &me, "Excess Flood");
       }
-      return 1;
     }
-
     /*
-     * Before we even think of parsing what we just read, stick
-     * it on the end of the receive queue and do it when its
-     * turn comes around.
+     * Before we even think of parsing what we just read, stick it on the end
+     * of the receive queue and do it when its turn comes around.  WebSocket
+     * input was already decoded into recvQ above.
      */
-    if (length > 0 && dbuf_put(&(cli_recvQ(cptr)), readbuf, length) == 0)
+    else if (length > 0 && dbuf_put(&(cli_recvQ(cptr)), readbuf, length) == 0)
       return exit_client(cptr, cptr, &me, "dbuf_put fail");
 
     Debug((DEBUG_DEBUG, "dbuf: %u maxfl: %u", DBufLength(&(cli_recvQ(cptr))), GetMaxFlood(cptr)));

--- a/ircd/websocket.c
+++ b/ircd/websocket.c
@@ -505,16 +505,12 @@ static int websocket_write_pong(struct Client *cptr, const unsigned char *payloa
 
 /*
  * Parse one WebSocket frame; payload (text/binary/continuation) is pushed into
- * recvQ for line reassembly. *msg_ready is set to 1 when a data/continuation
- * frame completes a logical message (FIN set), so the caller knows when to drain
- * recvQ; fragmented messages (FIN=0 followed by continuation frames) accumulate
- * until the final fragment.
+ * recvQ for line reassembly. On the final fragment (FIN set) a newline is
+ * appended so recvQ holds a complete IRC line; fragmented messages (FIN=0
+ * followed by continuation frames) accumulate until the final fragment.
  * Return value: >0 bytes consumed from buf, 0 if more data needed, <0 on dbuf_put failure.
  */
-int websocket_parse_frame(struct Client *cptr, const char *buf, size_t buflen,
-                          int *msg_ready) {
-    if (msg_ready)
-        *msg_ready = 0;
+int websocket_parse_frame(struct Client *cptr, const char *buf, size_t buflen) {
     if (buflen < 2) return 0; /* need frame header */
 
     unsigned char fin = (buf[0] & 0x80) ? 1 : 0;
@@ -604,10 +600,10 @@ int websocket_parse_frame(struct Client *cptr, const char *buf, size_t buflen,
         if (dbuf_put(&(cli_recvQ(cptr)), irc_line, deliver) == 0)
             return -1; /* Buffer error */
 
-        /* Deliver only once the message is complete (FIN); otherwise keep
-         * buffering subsequent continuation fragments in recvQ. */
-        if (msg_ready)
-            *msg_ready = fin;
+        /* Terminate the IRC line on the final fragment; continuation frames
+         * (FIN=0) keep accumulating in recvQ until then. */
+        if (fin && dbuf_put(&(cli_recvQ(cptr)), "\n", 1) == 0)
+            return -1;
     }
 
     return header_len + payload_len;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from irc_client import IRCClient
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 HUB = {"host": "127.0.0.1", "port": 6667, "server_port": 4400, "name": "hub.test.net"}
-LEAF1 = {"host": "127.0.0.1", "port": 6668, "server_port": 4401, "name": "leaf1.test.net"}
+LEAF1 = {"host": "127.0.0.1", "port": 6668, "server_port": 4401, "name": "leaf1.test.net", "exempt_port": 6690}
 LEAF2 = {"host": "127.0.0.1", "port": 6669, "server_port": 4402, "name": "leaf2.test.net"}
 
 TLS_HUB = {

--- a/tests/docker/ircd-hub.conf
+++ b/tests/docker/ircd-hub.conf
@@ -75,8 +75,20 @@ Class {
         maxlinks = 100;
 };
 
+# maxflood above the CLIENT_FLOOD default (1024) => flood-exempt from throttling.
+Class {
+        name = "Exempt";
+        pingfreq = 1 minutes 30 seconds;
+        sendq = 160000;
+        maxflood = 262144;
+        maxlinks = 100;
+};
+
 Client { ip = "*"; class = "Local"; username = "ident"; maxlinks = 50; };
 Client { ip = "*"; class = "Local"; maxlinks = 50; };
+# Connections on the exempt WebSocket port (7002) are flood-exempt. Defined
+# last so it is matched first (Client blocks are checked in reverse order).
+Client { ip = "*"; port = 7002; class = "Exempt"; maxlinks = 50; };
 
 Operator {
         local = no;
@@ -91,6 +103,8 @@ Port { server = yes; port = 4400; };
 Port { port = 6667; };
 Port { websocket = yes; port = 7000; };
 Port { websocket = yes; cloudflare = yes; port = 7001; };
+# Exempt WebSocket port: connections here land in the Exempt class.
+Port { websocket = yes; port = 7002; };
 
 Features {
         "HUB" = "TRUE";

--- a/tests/docker/ircd-leaf1.conf
+++ b/tests/docker/ircd-leaf1.conf
@@ -40,7 +40,19 @@ Class {
         maxlinks = 100;
 };
 
+# Class with maxflood above the CLIENT_FLOOD default (1024): its clients are
+# exempt from input throttling. Used by tests/pr69_exempt_throttle/.
+Class {
+        name = "Exempt";
+        pingfreq = 1 minutes 30 seconds;
+        sendq = 160000;
+        maxflood = 262144;
+        maxlinks = 100;
+};
+
 Client { ip = "*"; class = "Local"; };
+# Route clients that connect on the dedicated exempt port (6690) into theExempt class.
+Client { ip = "*"; port = 6690; class = "Exempt"; };
 
 Operator {
         local = no;
@@ -52,6 +64,8 @@ Operator {
 
 Port { server = yes; port = 4401; };
 Port { port = 6668; };
+# Dedicated client port whose connections land in the Exempt class (see above).
+Port { port = 6690; };
 
 Features {
         "NODNS" = "TRUE";

--- a/tests/pr69_exempt_throttle/test_fix.py
+++ b/tests/pr69_exempt_throttle/test_fix.py
@@ -1,0 +1,130 @@
+"""Tests for PR #69: exempt raised-maxflood clients from input throttling.
+
+ircu throttles how fast it processes commands *from* a local client: after a
+client's accumulated command penalty (cli_since) runs ~10s ahead of the clock,
+the read loop stops draining its recvQ and defers the rest to a 2-second timer
+(ircd/s_bsd.c). A connection class whose `maxflood` exceeds the CLIENT_FLOOD
+default (1024) marks its clients FLAG_EXEMPT_THROTTLE, which bypasses that gate
+so their commands are processed as fast as they arrive.
+
+The throttle governs the *sender's* input processing, so the observable effect
+is downstream: a throttled sender's PRIVMSGs are processed slowly, so a
+recipient sees them dribble in; an exempt sender's are processed all at once,
+so the recipient sees them immediately.
+
+Test setup (see tests/docker/ircd-leaf1.conf):
+  - Class "Exempt" has maxflood = 262144 (> 1024) -> flood-exempt.
+  - A Client block routes connections on the dedicated exempt port (6690)
+    into that class. Listener port is chosen (rather than username) because it
+    is known at accept time; Client-block username matching keys off the
+    *ident* username, which is empty without an identd (as in this harness).
+
+The 2-second deferral is a hard floor. With 15 penalty-incurring messages a 
+non-exempt sender can only clear ~5 in the first drain (5 * ~2s penalty reaches 
+the ~10s gate), then ~1 per 2s timer tick -- so it CANNOT deliver all 15 within 
+the short window. An exempt sender clears all 15 in a single drain. We assert 
+the withholding, not an exact eventual total, so no long waits and no dependence 
+on machine speed (localhost delivery is sub-millisecond).
+"""
+
+import asyncio
+
+import pytest
+
+from irc_client import IRCClient
+
+pytestmark = pytest.mark.multi_server
+
+# Number of back-to-back messages in the burst. Large enough that a throttled
+# sender is guaranteed to have unprocessed messages left inside FAST_WINDOW.
+BURST = 15
+# Window in which an exempt sender delivers everything and a throttled one does
+# not. Comfortably above localhost delivery time, well below the throttle's
+# multi-second deferral, so both directions hold with margin.
+FAST_WINDOW = 4.0
+
+
+async def make_client_on(server, nick, port=None):
+    client = IRCClient()
+    await client.connect(server["host"], port or server["port"])
+    await client.register(nick, "testuser", "Test User")
+    return client
+
+
+async def burst_privmsgs(sender, target_nick, count):
+    """Fire `count` PRIVMSGs at target_nick as fast as the socket accepts them."""
+    for i in range(count):
+        await sender.send(f"PRIVMSG {target_nick} :flood {i}")
+
+
+async def count_privmsgs_within(recipient, sender_nick, expected, window):
+    """Count PRIVMSGs from sender_nick that arrive within `window` seconds.
+
+    Stops early once `expected` have arrived. Returns the count reached.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + window
+    count = 0
+    while count < expected:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            msg = await recipient.recv(timeout=remaining)
+        except (asyncio.TimeoutError, ConnectionError):
+            break
+        if (
+            msg.command == "PRIVMSG"
+            and msg.prefix
+            and msg.prefix.split("!", 1)[0] == sender_nick
+        ):
+            count += 1
+    return count
+
+
+async def cleanup(*clients):
+    for client in clients:
+        try:
+            await client.send("QUIT :cleanup")
+        except Exception:
+            pass
+        await client.disconnect()
+
+
+async def test_exempt_client_not_throttled(ircd_network):
+    """A raised-maxflood (Exempt class) sender's whole burst lands immediately."""
+    leaf = ircd_network["leaf1"]
+    recipient = await make_client_on(leaf, "rcpt69a")
+    # Connect on the exempt port -> routed into the Exempt class on leaf1.
+    sender = await make_client_on(leaf, "exsnd69a", port=leaf["exempt_port"])
+    try:
+        await burst_privmsgs(sender, "rcpt69a", BURST)
+        got = await count_privmsgs_within(recipient, "exsnd69a", BURST, FAST_WINDOW)
+        assert got == BURST, (
+            f"exempt sender should not be throttled, but recipient only got "
+            f"{got}/{BURST} messages within {FAST_WINDOW}s"
+        )
+    finally:
+        await cleanup(recipient, sender)
+
+
+async def test_normal_client_is_throttled(ircd_network):
+    """Control: a default-class sender is throttled, so the burst is withheld.
+
+    Proves the exempt test above is actually exercising the throttle -- the
+    same burst from a normal (Local class) sender must NOT all arrive in the
+    window, because the 2-second deferral holds the tail back.
+    """
+    leaf = ircd_network["leaf1"]
+    recipient = await make_client_on(leaf, "rcpt69b")
+    # Default port -> Local class (normal throttling applies).
+    sender = await make_client_on(leaf, "nrmsnd69b")
+    try:
+        await burst_privmsgs(sender, "rcpt69b", BURST)
+        got = await count_privmsgs_within(recipient, "nrmsnd69b", BURST, FAST_WINDOW)
+        assert got < BURST, (
+            f"normal sender should be throttled, but recipient got all "
+            f"{got}/{BURST} messages within {FAST_WINDOW}s (throttle not applied?)"
+        )
+    finally:
+        await cleanup(recipient, sender)

--- a/tests/pr_websocket/test_websocket_msgbuf_leak.py
+++ b/tests/pr_websocket/test_websocket_msgbuf_leak.py
@@ -22,7 +22,7 @@ import pytest
 from irc_client import IRCClient
 from ws_frame_helpers import (
     HOST,
-    WS_PORT,
+    WS_EXEMPT_PORT,
     masked_text_frame,
     raw_ws_connect,
     read_server_frame,
@@ -76,7 +76,8 @@ async def test_ws_outbound_does_not_leak_msgbufs(ircd_hub):
     baseline = await _msgbuf_used(oper)
 
     # Connect a WS client and make the server emit a large volume of frames.
-    r, w = await raw_ws_connect(WS_PORT)
+    # Use the exempt port so the rapid PING burst is not flood-throttled.
+    r, w = await raw_ws_connect(WS_EXEMPT_PORT)
     assert await register_over_raw_ws(r, w, "leakws", timeout=15.0)
 
     n = 400

--- a/tests/pr_websocket/test_websocket_stress.py
+++ b/tests/pr_websocket/test_websocket_stress.py
@@ -23,6 +23,7 @@ HOST = "127.0.0.1"
 NORMAL_PORT = 6667
 WS_PORT = 7000
 WS_URL = f"ws://{HOST}:{WS_PORT}/"
+WS_EXEMPT_URL = f"ws://{HOST}:7002/"  # flood-exempt port for high-rate senders
 
 # Raw RFC6455 opening handshake (same key as tests/test_websocket_protocol_confusion.py)
 _WS_RAW_UPGRADE = (
@@ -101,7 +102,7 @@ async def test_ws_stress_parallel_clients(ircd_hub):
 async def test_ws_stress_rapid_privmsg_with_background_drain(ircd_hub):
     """High rate of sends while a task drains incoming (PING + numerics)."""
     ws = IRCWebSocketClient()
-    await ws.connect(WS_URL, subprotocols=["text.ircv3.net"])
+    await ws.connect(WS_EXEMPT_URL, subprotocols=["text.ircv3.net"])
     await ws.register("wsflood", "t", "Flood")
     await ws.send("JOIN #wsflood")
 

--- a/tests/pr_websocket/test_websocket_throttle.py
+++ b/tests/pr_websocket/test_websocket_throttle.py
@@ -1,0 +1,98 @@
+"""WebSocket input throttling: normal clients are throttled, exempt are not.
+
+The line-based reader has always throttled how fast it processes a client's
+commands (the cli_since penalty gate); the WebSocket reader now shares that
+same drain path. A raised-maxflood class (FLAG_EXEMPT_THROTTLE) bypasses it.
+
+A WS sender fires a burst of PRIVMSGs at a plain recipient on the same hub;
+we count how many arrive in a short window. A normal sender is throttled so
+only the first few land; an exempt sender (connected on the exempt WS port,
+7002) is not, so all of them land. See tests/docker/ircd-hub.conf.
+"""
+
+import asyncio
+
+import pytest
+
+from irc_client import IRCClient
+from irc_ws_client import IRCWebSocketClient
+from ws_frame_helpers import HOST, WS_PORT, WS_EXEMPT_PORT
+
+NORMAL_PORT = 6667
+BURST = 15
+FAST_WINDOW = 4.0
+
+
+async def recipient_client(nick):
+    c = IRCClient()
+    await c.connect(HOST, NORMAL_PORT)
+    await c.register(nick, "testuser", "Test User")
+    return c
+
+
+async def ws_sender(nick, port):
+    c = IRCWebSocketClient()
+    await c.connect(f"ws://{HOST}:{port}")
+    await c.register(nick, "testuser", "Test User")
+    return c
+
+
+async def burst_privmsgs(sender, target, count):
+    for i in range(count):
+        await sender.send(f"PRIVMSG {target} :flood {i}")
+
+
+async def count_within(recipient, sender_nick, expected, window):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + window
+    count = 0
+    while count < expected:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            msg = await recipient.recv(timeout=remaining)
+        except (asyncio.TimeoutError, ConnectionError):
+            break
+        if (msg.command == "PRIVMSG" and msg.prefix
+                and msg.prefix.split("!", 1)[0] == sender_nick):
+            count += 1
+    return count
+
+
+async def cleanup(*clients):
+    for c in clients:
+        try:
+            await c.disconnect()
+        except Exception:
+            pass
+
+
+async def test_exempt_ws_client_not_throttled(ircd_hub):
+    """A WS sender on the exempt port delivers its whole burst immediately."""
+    recipient = await recipient_client("wsrcpt_e")
+    sender = await ws_sender("wssnd_e", WS_EXEMPT_PORT)
+    try:
+        await burst_privmsgs(sender, "wsrcpt_e", BURST)
+        got = await count_within(recipient, "wssnd_e", BURST, FAST_WINDOW)
+        assert got == BURST, (
+            f"exempt WS sender should not be throttled, but recipient got "
+            f"{got}/{BURST} within {FAST_WINDOW}s"
+        )
+    finally:
+        await cleanup(recipient, sender)
+
+
+async def test_normal_ws_client_is_throttled(ircd_hub):
+    """Control: a WS sender on the normal port is throttled, withholding the tail."""
+    recipient = await recipient_client("wsrcpt_n")
+    sender = await ws_sender("wssnd_n", WS_PORT)
+    try:
+        await burst_privmsgs(sender, "wsrcpt_n", BURST)
+        got = await count_within(recipient, "wssnd_n", BURST, FAST_WINDOW)
+        assert got < BURST, (
+            f"normal WS sender should be throttled, but recipient got all "
+            f"{got}/{BURST} within {FAST_WINDOW}s"
+        )
+    finally:
+        await cleanup(recipient, sender)

--- a/tests/ws_frame_helpers.py
+++ b/tests/ws_frame_helpers.py
@@ -13,6 +13,7 @@ import struct
 HOST = "127.0.0.1"
 WS_PORT = 7000
 WS_CF_PORT = 7001
+WS_EXEMPT_PORT = 7002  # connections here are flood-exempt (Exempt class)
 
 # Minimal RFC 6455 opening handshake (key is the example from the RFC).
 RAW_HANDSHAKE = (


### PR DESCRIPTION
## Summary
The WebSocket reader dispatched each completed frame inline with no
`cli_since` penalty gate, so WebSocket clients were never throttled. It
also drained recvQ wholesale on every completed message, so a rapid burst
of complete commands never accumulated in recvQ and never tripped Excess
Flood — leaving WebSocket connections with an effectively unbounded
command rate that line clients never had.

`websocket_parse_frame` now terminates each completed message with a
newline, and the WebSocket reader falls through to the same drain loop and
2-second timer the line reader already uses. The bespoke WS dispatch and
the now-dead `dbuf_getframe` are removed, so the change is a net
simplification.

## Behaviour changes
- WebSocket clients are now throttled identically to line clients.
- **Security:** a WebSocket burst that outruns the throttle now
  accumulates in recvQ and is subject to Excess Flood, closing the
  previously-unbounded command-rate gap.
- Clients in a raised-maxflood class (`FLAG_EXEMPT_THROTTLE`) bypass the
  throttle.

## Testing
- New `pr_websocket/test_websocket_throttle.py`: normal WS client is
  throttled, exempt WS client is not.
- Full `pr_websocket/` suite passes. Two stress tests that deliberately
  flood (`test_websocket_msgbuf_leak`,
  `test_ws_stress_rapid_privmsg_with_background_drain`) now use a
  flood-exempt WS port (7002), since a Local-class flood is correctly cut
  off for Excess Flood.
- Adds an `Exempt` class + WS port 7002 to the test hub config.
