### PR TITLE
Fix secure-path groups on a standalone server

### DIFF
--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -54,6 +54,7 @@
 #include "s_conf.h"
 #include "s_debug.h"
 #include "s_misc.h"
+#include "s_serv.h"
 #include "s_stats.h"
 #include "sasl.h"
 #include "send.h"
@@ -792,6 +793,12 @@ int main(int argc, char **argv) {
 
   hAddClient(&me);
   SetIPv6(&me);
+
+  /* Seed &me's secure group before any server links.  Without this,
+   * a standalone server keeps sid == 0 and same-server TLS clients
+   * are never reported as sharing a secure path.
+   */
+  compute_secure_path_groups();
 
   write_pidfile();
   init_counters();

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -289,7 +289,8 @@ int server_estab(struct Client *cptr, struct ConfItem *aconf)
  * links forms a group of its own, so two TLS clients on the same
  * server share a secure path (no server link is involved between
  * them).
- * This function should be called whenever the network topology changes.
+ * This function should be called at startup (after &me is registered)
+ * and whenever the network topology changes.
  */
 void compute_secure_path_groups(void)
 {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,27 @@ def ircd_network():
 
 
 @pytest.fixture(scope="session")
+def ircd_tls_hub():
+    """Start only the TLS hub — no peer servers ever link.
+
+    Use this for standalone secure-path coverage: compute_secure_path_groups()
+    must run at boot, because link/SQUIT never fires on a lone server.
+    """
+    docker_compose("down", check=False)
+    _start_services("ircd-tls-hub")
+    try:
+        wait_for_port(TLS_HUB["host"], TLS_HUB["port"])
+        wait_for_port(TLS_HUB["host"], TLS_HUB["tls_port"])
+        wait_for_port(TLS_HUB["host"], TLS_HUB["wss_port"])
+        wait_for_port(TLS_HUB["host"], TLS_HUB["server_port"])
+        # Ident lookups during registration can take a moment on cold start.
+        time.sleep(2)
+        yield TLS_HUB
+    finally:
+        docker_compose("down", check=False)
+
+
+@pytest.fixture(scope="session")
 def ircd_tls_network():
     """Start TLS-enabled hub and leaf containers. Session-scoped."""
     docker_compose("down", check=False)

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -20,6 +20,7 @@ markers = [
     "single_server: tests that need only the hub server",
     "multi_server: tests that need the full hub + 2 leaves topology",
     "tls: tests that need the TLS hub + leaf containers",
+    "tls_single: tests that need only the TLS hub (no peer servers)",
     "websocket_stress: aggressive WebSocket load / edge-case tests (pr_websocket/, hub + port 7000)",
     "limits: tests that need the dedicated limits server",
 ]

--- a/tests/secure_path/test_review_findings.py
+++ b/tests/secure_path/test_review_findings.py
@@ -295,9 +295,9 @@ async def test_same_server_tls_clients_share_secure_path(ircd_tls_network):
     server-to-server hop is involved), even when that server has no TLS
     server links.
 
-    The buggy code only assigns the local server a secure group when it has
-    TLS *server* links, so the WHOIS 671 secure-path suffix never appears on
-    a standalone server.
+    Prefer tests/secure_path/test_single_server.py for the true never-linked
+    case: this test SQUITs the leaf, which itself recomputes groups and can
+    mask a missing startup call to compute_secure_path_groups().
     """
     hub = ircd_tls_network["hub"]
     op = await _make_oper(hub, "srf4op")

--- a/tests/secure_path/test_single_server.py
+++ b/tests/secure_path/test_single_server.py
@@ -1,0 +1,148 @@
+"""Secure-path coverage for a standalone TLS server (no peer links).
+
+Reproduces the bug where compute_secure_path_groups() was only invoked on
+server link/SQUIT, so a lone ircd left &me.sid == 0 and same-server TLS
+clients never shared a secure path.
+
+These tests use the ircd_tls_hub fixture (TLS hub only — the leaf is never
+started), so no SQUIT/CONNECT can mask a missing startup computation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from irc_client import IRCClient, Message
+
+pytestmark = [pytest.mark.tls, pytest.mark.tls_single, pytest.mark.asyncio]
+
+
+async def _collect_whois(client: IRCClient, target: str, timeout: float = 10.0) -> list[Message]:
+    await client.send(f"WHOIS {target}")
+    return await client.collect_until("318", timeout=timeout)
+
+
+def _whois_secure_text(msgs: list[Message]) -> str | None:
+    for msg in msgs:
+        if msg.command == "671":
+            return msg.params[-1] if msg.params else None
+    return None
+
+
+async def _join(client: IRCClient, channel: str) -> None:
+    await client.send(f"JOIN {channel}")
+    await client.wait_for("JOIN", timeout=5.0)
+
+
+async def _channel_mode_flags(client: IRCClient, channel: str) -> str | None:
+    await client.send(f"MODE {channel}")
+    msgs = await client.collect_until("324", timeout=5.0)
+    for msg in msgs:
+        if msg.command == "324" and len(msg.params) >= 3:
+            return msg.params[2]
+    return None
+
+
+async def _tls_client(hub: dict, nick: str) -> IRCClient:
+    client = IRCClient()
+    await client.connect_tls(hub["host"], hub["tls_port"])
+    await client.register(nick, "testuser", nick)
+    return client
+
+
+async def test_standalone_tls_clients_share_secure_path(ircd_tls_hub):
+    """Several TLS clients on a never-linked server share a secure path."""
+    hub = ircd_tls_hub
+    nicks = ["sspath1", "sspath2", "sspath3", "sspath4"]
+    clients = [await _tls_client(hub, nick) for nick in nicks]
+    try:
+        observer, *targets = clients
+        for target in targets:
+            msgs = await _collect_whois(observer, target.nick)
+            text = _whois_secure_text(msgs)
+            assert text is not None, (
+                f"expected 671 for TLS peer {target.nick}, got {msgs}"
+            )
+            assert "secure network path" in text.lower(), (
+                f"standalone TLS clients must share a secure path, "
+                f"got {text!r} for WHOIS {target.nick} "
+                "(missing compute_secure_path_groups at startup?)"
+            )
+    finally:
+        for client in clients:
+            await client.disconnect()
+
+
+async def test_standalone_plaintext_observer_omits_path_suffix(ircd_tls_hub):
+    """Plaintext observers still see 671 for TLS targets, without the path suffix."""
+    hub = ircd_tls_hub
+    tls_user = await _tls_client(hub, "ssplaint")
+    plain = IRCClient()
+    await plain.connect(hub["host"], hub["port"])
+    await plain.register("ssplaino", "testuser", "Plain observer")
+    try:
+        msgs = await _collect_whois(plain, "ssplaint")
+        text = _whois_secure_text(msgs)
+        assert text is not None, f"expected 671 for TLS target, got {msgs}"
+        assert "secure network path" not in text.lower(), (
+            f"plaintext observer must not see path suffix, got {text!r}"
+        )
+    finally:
+        await plain.disconnect()
+        await tls_user.disconnect()
+
+
+async def test_standalone_channel_stays_Z_with_several_tls_clients(ircd_tls_hub):
+    """+Z with multiple same-server TLS members stays +Z (single secure group)."""
+    hub = ircd_tls_hub
+    channel = "#sszmany"
+    nicks = ["ssz_a", "ssz_b", "ssz_c"]
+    clients = [await _tls_client(hub, nick) for nick in nicks]
+    try:
+        for client in clients:
+            await _join(client, channel)
+
+        await clients[0].send(f"MODE {channel} +Z")
+        await asyncio.sleep(0.5)
+
+        flags = await _channel_mode_flags(clients[0], channel)
+        assert flags is not None
+        assert "Z" in flags, (
+            f"expected +Z on standalone server with several TLS clients, "
+            f"got {flags!r}"
+        )
+        assert "z" not in flags, (
+            f"did not expect local +z when all members share one group, "
+            f"got {flags!r}"
+        )
+    finally:
+        for client in clients:
+            await client.disconnect()
+
+
+async def test_standalone_mixed_channel_shows_local_z(ircd_tls_hub):
+    """TLS + plaintext members on a standalone server expose local +z."""
+    hub = ircd_tls_hub
+    channel = "#sszmix"
+
+    tls_user = await _tls_client(hub, "ssmix_t")
+    plain = IRCClient()
+    await plain.connect(hub["host"], hub["port"])
+    await plain.register("ssmix_p", "testuser", "Plain member")
+    try:
+        await _join(tls_user, channel)
+        await _join(plain, channel)
+
+        await tls_user.send(f"MODE {channel} +Z")
+        await asyncio.sleep(0.5)
+
+        flags = await _channel_mode_flags(tls_user, channel)
+        assert flags is not None
+        assert "z" in flags, (
+            f"expected local +z for mixed TLS/plaintext members, got {flags!r}"
+        )
+    finally:
+        await plain.disconnect()
+        await tls_user.disconnect()


### PR DESCRIPTION
compute_secure_path_groups() only ran on link/SQUIT, so a lone ircd left &me.sid at 0 and same-server TLS clients never shared a secure path. Seed groups at startup and cover the never-linked case in tests.