### PR TITLE
fix: don't stamp @time= on server<->services RPC (XQUERY/XREPLY)

### DIFF
--- a/ircd/msg_tag.c
+++ b/ircd/msg_tag.c
@@ -368,6 +368,11 @@ msg_tag_s2s_needs_time(const char *tok)
       || !ircd_strcmp(tok, TOK_JUPE)
       || !ircd_strcmp(tok, TOK_GLINE)
       || !ircd_strcmp(tok, TOK_SLINE)
+      /* Server<->services RPC: consumed by services software that parses
+       * P10 fields positionally and does not strip tags.  A @time= prefix
+       * shifts every field and breaks SASL/spamfilter routing. */
+      || !ircd_strcmp(tok, TOK_XQUERY)
+      || !ircd_strcmp(tok, TOK_XREPLY)
       || !ircd_strcmp(tok, TOK_DESTRUCT))
     return 0;
   return 1;

--- a/tests/pr_msgtags_compat/test_s2s_service_rpc_untagged.py
+++ b/tests/pr_msgtags_compat/test_s2s_service_rpc_untagged.py
@@ -1,0 +1,72 @@
+"""Regression: server<->services RPC must not carry a client @time tag on S2S.
+
+XQUERY/XREPLY (P10 XQ/XR) are internal server-to-services RPC (SASL auth,
+spamfilter). They are consumed by services software that parses P10 fields
+positionally and does not strip IRCv3 message-tags. The S2S time-tagging
+introduced with message-tags used a blacklist that missed XQ/XR, so the hub
+began prepending `@time=...` to XQUERY -- shifting every field by one and
+breaking SASL routing ('sasl:<cookie>' landed one slot over) and spamfilter
+XREPLY routing (the hub numeric became the tag).
+
+A client-facing relayed event (PRIVMSG/NOTICE/etc.) legitimately keeps its
+@time on S2S; only the service-RPC commands must stay untagged.
+"""
+
+import asyncio
+
+import pytest
+
+from irc_client import IRCClient
+from p10_server import P10Server
+
+pytestmark = pytest.mark.single_server
+
+
+@pytest.fixture
+async def services(ircd_hub):
+    """Fake P10 services server linked to the hub, with SASL enabled."""
+    srv = P10Server(name="services.test.net", numeric=4, password="testpass")
+    await srv.connect(ircd_hub["host"], ircd_hub["server_port"])
+    await srv.handshake()
+    await srv.send_config("sasl.server", "services.test.net")
+    await srv.send_config("sasl.mechanisms", "PLAIN")
+    await asyncio.sleep(0.5)
+    yield srv
+    await srv.disconnect()
+
+
+async def test_xquery_has_no_time_tag(ircd_hub, services):
+    """The XQUERY the hub sends to services must be plain P10 (no @tag prefix).
+
+    Asserts on the raw wire line so a leading `@time=` is caught directly,
+    independent of any tag-stripping the harness does for token matching.
+    """
+    client = IRCClient()
+    await client.connect(ircd_hub["host"], ircd_hub["port"])
+
+    try:
+        await client.send("CAP LS 302")
+        msg = await client.wait_for("CAP", timeout=5.0)
+        assert "sasl" in msg.params[-1], "hub does not advertise sasl"
+
+        await client.send("CAP REQ :sasl")
+        await client.wait_for("CAP", timeout=5.0)
+        await client.send("AUTHENTICATE PLAIN")
+
+        line = await services.wait_for_token("XQ", timeout=5.0)
+
+        # Raw line must be classic P10: first field is the hub numeric, not a
+        # message-tag section.
+        assert not line.lstrip().startswith("@"), f"XQUERY carried a tag: {line!r}"
+        parts = line.split()
+        assert "time=" not in parts[0], f"XQUERY carried a time tag: {line!r}"
+        # Classic P10 layout: <hubnum> XQ <svcnum> <routing> :<payload>.
+        # A leading @time= would shift all of these one slot to the right.
+        assert parts[1] == "XQ", f"unexpected XQUERY layout: {line!r}"
+        assert parts[3].startswith("sasl:"), f"routing shifted by a tag: {line!r}"
+    finally:
+        try:
+            await client.send("QUIT :cleanup")
+        except Exception:
+            pass
+        await client.disconnect()


### PR DESCRIPTION
msg_tag_s2s_needs_time() is a blacklist: it strips @time= from known link/state/admin tokens and tags everything else on S2S.  It missed XQUERY (XQ) and XREPLY (XR), so the hub began prepending @time= to the SASL/spamfilter RPC it sends to a services server.

Services software parses P10 fields positionally and does not strip IRCv3 message-tags, so a leading @time= shifts every field by one:
  @time=... AB XQ AE sasl:1 :SASL ...
SASL routing ('sasl:<cookie>') landed one slot over (the tests read the services numeric 'AE' instead), and spamfilter XREPLY was addressed to the tag text instead of the hub numeric, so held messages were never released.  This broke pr65_sline (3) and pr_iauthverify SASL (4).

Exclude XQ/XR from S2S time-tagging.  These are internal server<->services RPC, not client-visible events, so they must stay classic P10.

Regression test asserts the XQUERY the hub emits during SASL is plain P10 with no @tag prefix.

NOTE: the blacklist remains fragile -- any client-facing command relayed to a tag-unaware services server (PRIVMSG/NOTICE to a service, tracked membership events) is still tagged.  The durable fix is to gate S2S tags on a per-link capability negotiated at handshake rather than the global NETWORK_FEATURES flag; tracked separately.