### PR TITLE
Forward client-only message tags on server links

### DIFF
--- a/include/msg_tag.h
+++ b/include/msg_tag.h
@@ -76,8 +76,9 @@ int msg_tag_s2s_needs_time(const char *tok);
 /** Format federated tags for a server-server wire line.
  * When \a invent_time is non-zero, include \a time (from \a tags or
  * \a local_time).  Otherwise never invent or forward \a time.
- * Also forwards other federated keys present in \a tags (e.g. \a batch).
- * Never includes \a account or client-only tags.
+ * Also forwards other federated keys present in \a tags (e.g. \a batch)
+ * and client-only (+) tags permitted by CLIENTTAGDENY, so they reach
+ * clients on other servers.  Never includes \a account.
  * @return Length of prefix beginning with '@' and ending with a space, or 0.
  */
 unsigned int msg_tag_format_s2s(char *buf, size_t buflen, struct MsgTag *tags,

--- a/ircd/msg_tag.c
+++ b/ircd/msg_tag.c
@@ -441,9 +441,16 @@ msg_tag_format_s2s(char *buf, size_t buflen, struct MsgTag *tags,
   for (tag = tags; tag; tag = tag->next) {
     if (!ircd_strcmp(tag->key, "time") || !ircd_strcmp(tag->key, "account"))
       continue;
-    if (msg_tag_key_client_only(tag->key))
-      continue;
-    if (!msg_tag_key_federated(tag->key))
+    if (msg_tag_key_client_only(tag->key)) {
+      /* Client-only (+) tags travel with the message so clients on other
+       * servers receive them too.  Our CLIENTTAGDENY applies here as well:
+       * tags from a local client were already filtered at parse time, and
+       * tags relayed from another server are subject to this server's
+       * policy before they leave it.  The receiving server filters again
+       * on delivery. */
+      if (!msg_tag_client_allowed(tag->key))
+        continue;
+    } else if (!msg_tag_key_federated(tag->key))
       continue;
     pos = msg_tag_append(pos, end, &wrote, tag->key, tag->value);
     if (!pos)

--- a/tests/pr_msgtags_compat/test_s2s_client_tags.py
+++ b/tests/pr_msgtags_compat/test_s2s_client_tags.py
@@ -1,0 +1,121 @@
+"""Client-only (+) tags must cross server links to clients on other servers.
+
+The S2S formatter used to drop every client-only tag, so a TAGMSG relayed
+to another server arrived as a bare ``TM #chan`` and a PRIVMSG lost its
+client tags at the first hop.  All earlier tag tests observed two clients
+on the same server, which is why this went unnoticed.
+
+The docker configs set ``CLIENTTAGDENY = "*,-example.com/foo"`` on hub and
+leaf, so ``+example.com/foo`` is the one client tag allowed end to end and
+``+blockedtag`` must be filtered at the sender's edge.
+"""
+
+import asyncio
+
+import pytest
+
+from irc_client import IRCClient
+from p10_server import P10Server
+
+from .helpers import join_synced, tag_has, tag_value
+
+pytestmark = pytest.mark.multi_server
+
+ALLOWED = "+example.com/foo"
+
+
+async def _client(host: str, port: int, nick: str) -> IRCClient:
+    c = IRCClient()
+    await c.connect(host, port)
+    await c.negotiate_cap(["message-tags"])
+    await c.register(nick, "testuser", f"User {nick}")
+    return c
+
+
+async def _cleanup(*clients: IRCClient) -> None:
+    for c in clients:
+        try:
+            await c.send("QUIT :cleanup")
+        except Exception:
+            pass
+        await c.disconnect()
+
+
+async def test_client_tags_reach_clients_on_other_servers(ircd_network):
+    """PRIVMSG, TAGMSG and private PRIVMSG keep +tags across hub -> leaf."""
+    hub = ircd_network["hub"]
+    leaf = ircd_network["leaf1"]
+    channel = "#ctagleaf"
+
+    sender = await _client(hub["host"], hub["port"], "ctagsnd")
+    leaf_obs = await _client(leaf["host"], leaf["port"], "ctagleaf")
+
+    try:
+        await join_synced(channel, sender, leaf_obs)
+        # Let the leaf learn about the hub-side member before speaking.
+        await asyncio.sleep(0.5)
+
+        await sender.send(f"@{ALLOWED}=chan PRIVMSG {channel} :tagged privmsg")
+        msg = await leaf_obs.wait_for_message_with_text(
+            "PRIVMSG", "tagged privmsg", timeout=10.0)
+        assert tag_value(msg.tags, ALLOWED) == "chan", msg.raw
+        assert tag_has(msg.tags, "time"), msg.raw
+
+        await sender.send(f"@{ALLOWED}=tm TAGMSG {channel}")
+        msg = await leaf_obs.wait_for("TAGMSG", timeout=10.0)
+        assert msg.params[0] == channel, msg.raw
+        assert tag_value(msg.tags, ALLOWED) == "tm", msg.raw
+
+        # A tag denied on the sender's server never leaves it; an allowed
+        # one on the same line still arrives.
+        await sender.send(
+            f"@+blockedtag=1;{ALLOWED}=mixed PRIVMSG {channel} :mixed tags")
+        msg = await leaf_obs.wait_for_message_with_text(
+            "PRIVMSG", "mixed tags", timeout=10.0)
+        assert not tag_has(msg.tags, "+blockedtag"), msg.raw
+        assert tag_value(msg.tags, ALLOWED) == "mixed", msg.raw
+
+        await sender.send(f"@{ALLOWED}=pm PRIVMSG ctagleaf :direct tagged")
+        msg = await leaf_obs.wait_for_message_with_text(
+            "PRIVMSG", "direct tagged", timeout=10.0)
+        assert tag_value(msg.tags, ALLOWED) == "pm", msg.raw
+    finally:
+        await _cleanup(sender, leaf_obs)
+
+
+async def test_client_tags_on_s2s_wire(ircd_network):
+    """The allowed client tag is present on the P10 line leaving the hub."""
+    hub = ircd_network["hub"]
+    channel = "#ctagwire"
+
+    peer = P10Server(name="services.test.net", numeric=4, password="testpass")
+    await peer.connect(hub["host"], hub["server_port"])
+    await peer.handshake()
+
+    sender = await _client(hub["host"], hub["port"], "ctagwire")
+    try:
+        bot = await peer.introduce_user("ctagbot")
+        await peer.send_join(bot, channel)
+        await join_synced(channel, sender)
+        await asyncio.sleep(0.3)
+
+        await sender.send(
+            f"@+blockedtag=1;{ALLOWED}=wire PRIVMSG {channel} :on the wire")
+
+        deadline = asyncio.get_event_loop().time() + 8.0
+        line = None
+        while asyncio.get_event_loop().time() < deadline:
+            remaining = deadline - asyncio.get_event_loop().time()
+            candidate = await peer._recv(timeout=max(remaining, 0.1))
+            if peer._get_token(candidate) == "P" and "on the wire" in candidate:
+                line = candidate
+                break
+        assert line, "S2S PRIVMSG never reached the peer"
+        assert line.startswith("@"), f"no tag prefix on S2S line: {line}"
+        prefix = line.split(" ", 1)[0]
+        assert f"{ALLOWED}=wire" in prefix.split(";"), line
+        assert "+blockedtag" not in prefix, line
+        assert prefix.startswith("@time="), line
+    finally:
+        await _cleanup(sender)
+        await peer.disconnect()


### PR DESCRIPTION
## Problem

`msg_tag_format_s2s()` dropped every client-only (`+`) tag before it even consulted CLIENTTAGDENY, so client tags never crossed a server link. A TAGMSG relayed to another server arrived as a bare `TM #chan`, and a PRIVMSG lost its client tags at the first hop. Only clients on the sending server ever saw them.

This has been the behaviour since the original message-tags commit (a060b5d). It went unnoticed because every tag test in the suite observed two clients on the same server; the only leaf-side assertions were for `@time`.

## Fix

Forward client-only tags that pass this server's CLIENTTAGDENY. Tags from a local client were already filtered at parse time, and the receiving server filters again on delivery, so the deny list still applies on both edges. Only `msg_tag.c` and its header comment change.

## Tests

New `tests/pr_msgtags_compat/test_s2s_client_tags.py` on the hub + leaf topology (the docker configs allow exactly `+example.com/foo`):

- A client on leaf1 receives the allowed tag on a channel PRIVMSG, a TAGMSG, and a private PRIVMSG from a hub client. A denied tag on the same line is stripped while the allowed one still arrives.
- A P10 peer on the hub sees the allowed tag in the outgoing P line's tag prefix, after `@time=`, with the denied tag absent.

Both tests fail on the unfixed formatter (tag missing on the leaf and on the wire) and pass with the fix.